### PR TITLE
Bug/graphql server timeouts apps 640

### DIFF
--- a/packages/cli/src/commands/graphql/server.ts
+++ b/packages/cli/src/commands/graphql/server.ts
@@ -56,11 +56,13 @@ export default class GraphQLServer extends Command<
         port: this.flags.port,
       })
       this.spinner.info(`GraphQL server is listening on ${handler.url}`)
-      process.on('SIGTERM', () => {
+      const handleProcessKillGracefully = () => {
         handler.stop(() => {
           this.spinner.succeed('Server stopped')
         })
-      })
+      }
+      process.on('SIGTERM', handleProcessKillGracefully)
+      process.on('SIGINT', handleProcessKillGracefully)
       // oclix/core has started to force kill all the commands after 10s, without an option to change this behaviour
       // Issue with more context: https://github.com/oclif/core/issues/464
       // Update in their docs making it clear (in response to the issue above): https://github.com/oclif/oclif.github.io/pull/166/files

--- a/packages/cli/src/commands/graphql/server.ts
+++ b/packages/cli/src/commands/graphql/server.ts
@@ -61,6 +61,10 @@ export default class GraphQLServer extends Command<
           this.spinner.succeed('Server stopped')
         })
       })
+      // oclix/core has started to force kill all the commands after 10s, without an option to change this behaviour
+      // Issue with more context: https://github.com/oclif/core/issues/464
+      // Update in their docs making it clear (in response to the issue above): https://github.com/oclif/oclif.github.io/pull/166/files
+      await new Promise(() => undefined)
     } catch (e) {
       this.spinner.fail((e as Error).message)
       return

--- a/packages/cli/test/graphql.test.ts
+++ b/packages/cli/test/graphql.test.ts
@@ -1,4 +1,5 @@
 import { execa } from 'execa'
+import { Readable } from 'stream'
 
 describe('graphql', () => {
   describe('graphql:schema', () => {
@@ -41,6 +42,67 @@ describe('graphql', () => {
             'You need to pass a composite runtime definition path either as an argument or via stdin'
           )
       ).toBe(true)
+    }, 60000)
+
+    test('graphql server starts', async () => {
+      const serverProcess = execa('bin/run.js', [
+        'graphql:server',
+        'test/mocks/runtime.composite.picture.post.json',
+        '--port=62433',
+      ])
+      let numChecks = 0
+      serverProcess.stderr?.on('data', (data: Readable) => {
+        if (numChecks === 0) {
+          // eslint-disable-next-line jest/no-conditional-expect
+          expect(
+            data
+              .toString()
+              .includes('GraphQL server is listening on http://localhost:62433/graphql')
+          ).toBe(true)
+          numChecks++
+        }
+      })
+      await Promise.race([
+        new Promise((resolve) =>
+          setTimeout(() => {
+            serverProcess.kill()
+            resolve(true)
+          }, 40000)
+        ),
+        serverProcess,
+      ])
+      expect.assertions(1)
+    }, 60000)
+
+    test('graphql server starts with --readonly flag', async () => {
+      const serverProcess = execa('bin/run.js', [
+        'graphql:server',
+        'test/mocks/runtime.composite.picture.post.json',
+        '--port=62610',
+        '--readonly',
+      ])
+      let numChecks = 0
+      serverProcess.stderr?.on('data', (data: Readable) => {
+        if (numChecks === 0) {
+          // eslint-disable-next-line jest/no-conditional-expect
+          expect(
+            data
+              .toString()
+              .includes('GraphQL server is listening on http://localhost:62610/graphql')
+          ).toBe(true)
+          numChecks++
+        }
+      })
+      await Promise.race([
+        new Promise((resolve) =>
+          setTimeout(() => {
+            serverProcess.kill()
+            resolve(true)
+          }, 40000)
+        ),
+        serverProcess,
+      ])
+      expect.assertions(1)
     }, 60000)
   })
 })


### PR DESCRIPTION
# Fixed the `graphql:server` command timing out after a change in `oclif/core`

## Description

`oclif` started automatically killing all the commands 10s after their `run()` method exits (https://github.com/oclif/oclif.github.io/pull/166/files, more context on the preferred solution to this in https://github.com/oclif/core/issues/464).

The solution upvoted by one of the devs is to prevent the `run()` method from exiting, so that's what this PR introduces.

## How Has This Been Tested?

- [X] Re-added the tests for `graphql:server` command which are now passing

## Definition of Done

Before submitting this PR, please make sure:

- [X] The work addresses the description and outcomes in the issue
- [X] I have added relevant tests for new or updated functionality
- [X] My code follows conventions, is well commented, and easy to understand
- [X] My code builds and tests pass without any errors or warnings
- [X] I have tagged the relevant reviewers
