### PR TITLE
Change the flags in model:list cli command

### DIFF
--- a/packages/cli/src/commands/model/list.ts
+++ b/packages/cli/src/commands/model/list.ts
@@ -29,7 +29,6 @@ export default class ModelList extends BaseCommand<ModelListFlags> {
       default: 'https://ceramic-private-clay.3boxlabs.com',
       char: 'i',
       description: 'URL of a Ceramic API that indexes all models',
-      env: 'INDEXER_URL',
     }),
     table: Flags.boolean({
       description: 'display the results as a table',

--- a/packages/cli/test/models.test.ts
+++ b/packages/cli/test/models.test.ts
@@ -97,14 +97,14 @@ describe('models', () => {
     }, 60000)
 
     test('model list succeeds', async () => {
-      const models = await execa('bin/run.js', ['model:list'])
+      const models = await execa('bin/run.js', ['model:list', '--indexer-url=http://localhost:7007'])
       expect(stripAnsi(models.stdout.toString()).includes('GenericProfile')).toBe(true)
       expect(stripAnsi(models.stdout.toString()).includes('SocialProfile')).toBe(true)
       expect(stripAnsi(models.stdout.toString()).includes('PersonProfile')).toBe(true)
     }, 60000)
 
     test('model list succeeds with --table argument', async () => {
-      const models = await execa('bin/run.js', ['model:list', '--table'])
+      const models = await execa('bin/run.js', ['model:list', '--indexer-url=http://localhost:7007', '--table'])
       expect(stripAnsi(models.stdout.toString()).includes('GenericProfile')).toBe(true)
       expect(stripAnsi(models.stdout.toString()).includes('SocialProfile')).toBe(true)
       expect(stripAnsi(models.stdout.toString()).includes('PersonProfile')).toBe(true)

--- a/website/docs/api/commands/cli.model.md
+++ b/website/docs/api/commands/cli.model.md
@@ -27,7 +27,7 @@ USAGE
 
 OPTIONS
   --table                  display results as a table rather than as formatted JSON
-  -i, --indexer-url        URL of a Ceramic API that indexes model streams. The default is https://ceramic-private-clay.3boxlabs.com
+  -i, --indexer-url        URL of a Ceramic API that indexes model streams.
 ```
 
 ### `composedb model:content`

--- a/website/docs/api/commands/cli.model.md
+++ b/website/docs/api/commands/cli.model.md
@@ -17,7 +17,7 @@ The group of [CLI](../modules/cli.md) `model:*` commands enables discovery of [M
 
 ### `composedb model:list`
 
-Display a paginated list of models indexed on the connected ceramic node.
+Display a paginated list of models indexed on the connected ceramic node, which needs to be indexing model streams.
 
 This currently is the main entry path to [Composites Discovery](../../guides/using-composites/discovery.mdx)
 
@@ -27,7 +27,7 @@ USAGE
 
 OPTIONS
   --table                  display results as a table rather than as formatted JSON
-  -c, --ceramic-url        Ceramic API URL
+  -i, --indexer-url        URL of a Ceramic API that indexes model streams. The default is https://ceramic-private-clay.3boxlabs.com
 ```
 
 ### `composedb model:content`

--- a/website/versioned_docs/version-0.2.x/api/commands/cli.model.md
+++ b/website/versioned_docs/version-0.2.x/api/commands/cli.model.md
@@ -27,7 +27,7 @@ USAGE
 
 OPTIONS
   --table                  display results as a table rather than as formatted JSON
-  -i, --indexer-url        URL of a Ceramic API that indexes model streams. The default is https://ceramic-private-clay.3boxlabs.com
+  -i, --indexer-url        URL of a Ceramic API that indexes model streams.
 ```
 
 ### `composedb model:content`

--- a/website/versioned_docs/version-0.2.x/api/commands/cli.model.md
+++ b/website/versioned_docs/version-0.2.x/api/commands/cli.model.md
@@ -17,7 +17,7 @@ The group of [CLI](../modules/cli.md) `model:*` commands enables discovery of [M
 
 ### `composedb model:list`
 
-Display a paginated list of models indexed on the connected ceramic node.
+Display a paginated list of models indexed on the connected ceramic node, which needs to be indexing model streams.
 
 This currently is the main entry path to [Composites Discovery](../../guides/using-composites/discovery.mdx)
 
@@ -27,7 +27,7 @@ USAGE
 
 OPTIONS
   --table                  display results as a table rather than as formatted JSON
-  -c, --ceramic-url        Ceramic API URL
+  -i, --indexer-url        URL of a Ceramic API that indexes model streams. The default is https://ceramic-private-clay.3boxlabs.com
 ```
 
 ### `composedb model:content`


### PR DESCRIPTION
# Removed `--ceramic-url` flag from `model:list` command and added `--indexer-url` flag instead

## Description

By default, the `model:list` command should connect to `https://ceramic-private-clay.3boxlabs.com`, as opposed to other commands which should connect to `localhost` by default. To keep the behaviour of `--ceramic-url` consistent across all commands, we decided to remove it from `model:list` and add `--indexer-url` instead.

This PR also removes the `--did-private-key` flag from `model:list`, as it doesn't need authentication.

The API docs are also updated in this PR. There's a separate [PR](https://github.com/ceramicstudio/js-composedb/pull/24) which updates the guides. 

## How Has This Been Tested?

- [X] Updated the tests

## Definition of Done

Before submitting this PR, please make sure:

- [X] The work addresses the description and outcomes in the issue
- [X] I have added relevant tests for new or updated functionality
- [X] My code follows conventions, is well commented, and easy to understand
- [X] My code builds and tests pass without any errors or warnings
- [X] I have tagged the relevant reviewers
- [X] I have updated the READMEs of affected packages
- [X] I have made corresponding changes to the documentation
- [X] The changes have been communicated to interested parties
