### PR TITLE
Use the provided private key to authenticate in graphql:server cli co…

### DIFF
--- a/packages/cli/src/commands/graphql/server.ts
+++ b/packages/cli/src/commands/graphql/server.ts
@@ -50,6 +50,7 @@ export default class GraphQLServer extends Command<
       const runtimeDefinition = JSON.parse(definitionFile.toString()) as RuntimeCompositeDefinition
       const handler = await serveGraphQL({
         ceramicURL: this.flags['ceramic-url'] || 'http://0.0.0.0:7007',
+        did: this.ceramic.did,
         definition: runtimeDefinition,
         readonly: this.flags.readonly,
         graphiql: this.flags.graphiql,


### PR DESCRIPTION
# Pass the (authticated) did from command's ceramic instance to the graphql server

## Description

By passing the did we can enable authenticated mutation against the graphql server

## How Has This Been Tested?

Describe the tests that you ran to verify your changes. Provide instructions for reproduction.

- [X] Tested manually

## Definition of Done

Before submitting this PR, please make sure:

- [X] The work addresses the description and outcomes in the issue
- [X] My code follows conventions, is well commented, and easy to understand
- [X] My code builds and tests pass without any errors or warnings
- [X] I have tagged the relevant reviewers
