### PR TITLE
Adapted an env var used in docs to reflect the change in latest ceramic release

### DIFF
--- a/website/docs/first-composite.mdx
+++ b/website/docs/first-composite.mdx
@@ -11,7 +11,7 @@ This page presents how to create your first composite and deploy it to your loca
 
 :::caution
 
-Because ComposeDB is still an experimental feature set built on top of Ceramic, if you want to use it with a Ceramic node, you need to set the `CERAMIC_ENABLE_EXPERIMENTAL_COMPOSEDB` environment variable to `true`, before running a node.
+Because ComposeDB is still an experimental feature set built on top of Ceramic, if you want to use it with a Ceramic node, you need to set the `CERAMIC_ENABLE_EXPERIMENTAL_COMPOSE_DB` environment variable to `true`, before running a node. Note that ComposeDB is not yet supported on Ceramic mainnet.
 
 :::
 

--- a/website/docs/first-composite.mdx
+++ b/website/docs/first-composite.mdx
@@ -9,6 +9,12 @@ This page presents how to create your first composite and deploy it to your loca
 
 ## Running a local Ceramic node
 
+:::caution
+
+Because ComposeDB is still an experimental feature set built on top of Ceramic, if you want to use it with a Ceramic node, you need to set the `CERAMIC_ENABLE_EXPERIMENTAL_COMPOSEDB` environment variable to `true`, before running a node.
+
+:::
+
 The following steps require a local Ceramic node to be running. If you do not already have it running, you can use the following command:
 
 <Tabs

--- a/website/versioned_docs/version-0.2.x/first-composite.mdx
+++ b/website/versioned_docs/version-0.2.x/first-composite.mdx
@@ -11,7 +11,7 @@ This page presents how to create your first composite and deploy it to your loca
 
 :::caution
 
-Because ComposeDB is still an experimental feature set built on top of Ceramic, if you want to use it with a Ceramic node, you need to set the `CERAMIC_ENABLE_EXPERIMENTAL_COMPOSEDB` environment variable to `true`, before running a node.
+Because ComposeDB is still an experimental feature set built on top of Ceramic, if you want to use it with a Ceramic node, you need to set the `CERAMIC_ENABLE_EXPERIMENTAL_COMPOSE_DB` environment variable to `true`, before running a node. Note that ComposeDB is not yet supported on Ceramic mainnet.
 
 :::
 

--- a/website/versioned_docs/version-0.2.x/first-composite.mdx
+++ b/website/versioned_docs/version-0.2.x/first-composite.mdx
@@ -11,7 +11,7 @@ This page presents how to create your first composite and deploy it to your loca
 
 :::caution
 
-Because ComposeDB is still an experimental feature set built on top of Ceramic, if you want to use it with a Ceramic node, you need to set the `CERAMIC_ENABLE_EXPERIMENTAL_INDEXING` environment variable to `true`, before running a node.
+Because ComposeDB is still an experimental feature set built on top of Ceramic, if you want to use it with a Ceramic node, you need to set the `CERAMIC_ENABLE_EXPERIMENTAL_COMPOSEDB` environment variable to `true`, before running a node.
 
 :::
 


### PR DESCRIPTION
# Adapted an env var used in docs to reflect the change in latest ceramic release

- [X] Built and reviewed the docs manually

