### PR TITLE
Updated ceramic deps

### DIFF
--- a/examples/next-notes/package.json
+++ b/examples/next-notes/package.json
@@ -10,7 +10,7 @@
     "lint": "next lint"
   },
   "dependencies": {
-    "@ceramicnetwork/http-client": "^2.3.4",
+    "@ceramicnetwork/http-client": "^2.3.5-rc.2",
     "@composedb/client": "workspace:^0.2.0",
     "@composedb/types": "workspace:^0.2.0",
     "@emotion/react": "^11.10.0",

--- a/examples/webpack-notes/package.json
+++ b/examples/webpack-notes/package.json
@@ -12,7 +12,7 @@
   },
   "dependencies": {
     "@apollo/client": "^3.6.9",
-    "@ceramicnetwork/http-client": "^2.3.4",
+    "@ceramicnetwork/http-client": "^2.3.5-rc.2",
     "@composedb/client": "workspace:^0.2.0",
     "@composedb/types": "workspace:^0.2.0",
     "@emotion/react": "^11.10.0",
@@ -32,7 +32,7 @@
     "uint8arrays": "^3.0.0"
   },
   "devDependencies": {
-    "@ceramicnetwork/common": "^2.5.0",
+    "@ceramicnetwork/common": "^2.6.1-rc.2",
     "@composedb/devtools": "workspace:^0.2.0",
     "@composedb/devtools-node": "workspace:^0.2.0",
     "@swc/core": "^1.2.244",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -69,11 +69,11 @@
     ]
   },
   "dependencies": {
-    "@ceramicnetwork/3id-did-resolver": "^2.1.7",
-    "@ceramicnetwork/http-client": "^2.3.4",
-    "@ceramicnetwork/stream-model": "^0.5.0",
-    "@ceramicnetwork/stream-model-instance": "^0.4.1",
-    "@ceramicnetwork/streamid": "^2.3.3",
+    "@ceramicnetwork/3id-did-resolver": "^2.1.8-rc.2",
+    "@ceramicnetwork/http-client": "^2.3.5-rc.2",
+    "@ceramicnetwork/stream-model": "^0.5.1-rc.2",
+    "@ceramicnetwork/stream-model-instance": "^0.4.2-rc.2",
+    "@ceramicnetwork/streamid": "^2.3.4-rc.0",
     "@composedb/client": "workspace:^0.2.1",
     "@composedb/devtools": "workspace:^0.2.1",
     "@composedb/devtools-node": "workspace:^0.2.1",
@@ -95,8 +95,8 @@
     "uint8arrays": "^3.0.0"
   },
   "devDependencies": {
-    "@ceramicnetwork/common": "^2.5.0",
-    "@ceramicnetwork/core": "^2.9.0",
+    "@ceramicnetwork/common": "^2.6.1-rc.2",
+    "@ceramicnetwork/core": "^2.10.0-rc.2",
     "@composedb/types": "workspace:^0.2.1",
     "@swc-node/register": "^1.5.1",
     "@types/fs-extra": "^9.0.13",

--- a/packages/cli/src/commands/model/list.ts
+++ b/packages/cli/src/commands/model/list.ts
@@ -58,7 +58,7 @@ export default class ModelList extends BaseCommand<ModelListFlags> {
       while (this.lastLoadedPageInfo?.hasNextPage) {
         await CliUx.ux.anykey('Press any key to load more models')
         this.spinner.start('Loading models...')
-        const nextPage: Page<StreamState> = await ceramicIndexer.index.queryIndex({
+        const nextPage: Page<StreamState | null> = await ceramicIndexer.index.queryIndex({
           first: this.getPageSize(),
           model: Model.MODEL,
           after: this.lastLoadedPageInfo?.endCursor,
@@ -74,14 +74,23 @@ export default class ModelList extends BaseCommand<ModelListFlags> {
     }
   }
 
-  getFieldsFromEdges(ceramicIndexer: CeramicClient, edges: Array<Edge<StreamState>>): Array<PartialModelDefinition> {
+  getFieldsFromEdges(ceramicIndexer: CeramicClient, edges: Array<Edge<StreamState | null>>): Array<PartialModelDefinition> {
     return edges.map((edge) => {
-      const stream = ceramicIndexer.buildStreamFromState(edge.node)
-      return {
-        id: stream.id.toString(),
-        name: (stream.content as Record<string, any>).name as string,
-        description: (stream.content as Record<string, any>).description as string,
+      if (edge && edge.node) {
+        const stream = ceramicIndexer.buildStreamFromState(edge.node)
+        return {
+          id: stream.id.toString(),
+          name: (stream.content as Record<string, any>).name as string,
+          description: (stream.content as Record<string, any>).description as string,
+        }
+      } else {
+        return {
+          id: '',
+          name: '',
+          description: '',
+        }
       }
+
     })
   }
 

--- a/packages/cli/src/commands/model/list.ts
+++ b/packages/cli/src/commands/model/list.ts
@@ -75,22 +75,22 @@ export default class ModelList extends BaseCommand<ModelListFlags> {
   }
 
   getFieldsFromEdges(ceramicIndexer: CeramicClient, edges: Array<Edge<StreamState | null>>): Array<PartialModelDefinition> {
+    const missingMessage = '<MISSING!!>'
     return edges.map((edge) => {
+      let id = missingMessage
+      let name = missingMessage
+      let description = missingMessage
       if (edge && edge.node) {
         const stream = ceramicIndexer.buildStreamFromState(edge.node)
-        return {
-          id: stream.id.toString(),
-          name: (stream.content as Record<string, any>).name as string,
-          description: (stream.content as Record<string, any>).description as string,
-        }
-      } else {
-        return {
-          id: '',
-          name: '',
-          description: '',
-        }
+        id = stream.id.toString()
+        name = (stream.content as Record<string, any>).name as string
+        description = (stream.content as Record<string, any>).description as string
       }
-
+      return {
+        id: id,
+        name: name,
+        description: description,
+      }
     })
   }
 

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -39,17 +39,17 @@
     "prepublishOnly": "package-check"
   },
   "dependencies": {
-    "@ceramicnetwork/http-client": "^2.3.4",
-    "@ceramicnetwork/stream-model": "^0.5.0",
-    "@ceramicnetwork/stream-model-instance": "^0.4.1",
-    "@ceramicnetwork/streamid": "^2.3.3",
+    "@ceramicnetwork/http-client": "^2.3.5-rc.2",
+    "@ceramicnetwork/stream-model": "^0.5.1-rc.2",
+    "@ceramicnetwork/stream-model-instance": "^0.4.2-rc.2",
+    "@ceramicnetwork/streamid": "^2.3.4-rc.0",
     "@composedb/graphql-scalars": "workspace:^0.2.1",
     "dataloader": "^2.1.0",
     "graphql": "^16.5.0",
     "graphql-relay": "^0.10.0"
   },
   "devDependencies": {
-    "@ceramicnetwork/common": "^2.6.0",
+    "@ceramicnetwork/common": "^2.6.1-rc.2",
     "@composedb/devtools": "workspace:^0.2.1",
     "@composedb/test-schemas": "workspace:^0.2.0",
     "@composedb/types": "workspace:^0.2.1",

--- a/packages/client/src/context.ts
+++ b/packages/client/src/context.ts
@@ -121,7 +121,7 @@ export class Context {
   /**
    * Query the index for a connection of documents.
    */
-  async queryConnection(query: ConnectionQuery): Promise<Connection<ModelInstanceDocument>> {
+  async queryConnection(query: ConnectionQuery): Promise<Connection<ModelInstanceDocument | null>> {
     return await queryConnection(this.#ceramic, query)
   }
 

--- a/packages/client/src/query.ts
+++ b/packages/client/src/query.ts
@@ -31,11 +31,11 @@ export function toIndexQuery(source: ConnectionQuery): IndexQuery {
 
 export function toRelayConnection(
   ceramic: CeramicApi,
-  page: Page<StreamState>
-): Connection<ModelInstanceDocument> {
+  page: Page<StreamState | null>
+): Connection<ModelInstanceDocument | null> {
   return {
     edges: page.edges.map(({ cursor, node }) => {
-      return { cursor, node: ceramic.buildStreamFromState<ModelInstanceDocument>(node) }
+      return { cursor, node: node ? ceramic.buildStreamFromState<ModelInstanceDocument>(node) : null }
     }),
     pageInfo: {
       ...page.pageInfo,
@@ -48,7 +48,7 @@ export function toRelayConnection(
 export async function queryConnection(
   ceramic: CeramicApi,
   query: ConnectionQuery
-): Promise<Connection<ModelInstanceDocument>> {
+): Promise<Connection<ModelInstanceDocument | null>> {
   const page = await ceramic.index.queryIndex(toIndexQuery(query))
   return toRelayConnection(ceramic, page)
 }
@@ -59,5 +59,5 @@ export async function querySingle(
 ): Promise<ModelInstanceDocument | null> {
   const result = await ceramic.index.queryIndex({ ...query, last: 1 })
   const edge = result.edges[0]
-  return edge ? ceramic.buildStreamFromState<ModelInstanceDocument>(edge.node) : null
+  return edge && edge.node ? ceramic.buildStreamFromState<ModelInstanceDocument>(edge.node) : null
 }

--- a/packages/client/src/schema.ts
+++ b/packages/client/src/schema.ts
@@ -158,7 +158,7 @@ class SchemaBuilder {
                 account,
                 args: ConnectionArguments,
                 ctx
-              ): Promise<Connection<ModelInstanceDocument> | null> => {
+              ): Promise<Connection<ModelInstanceDocument | null> | null> => {
                 return await ctx.queryConnection({ ...args, account, model: model.id })
               },
             }

--- a/packages/devtools-node/package.json
+++ b/packages/devtools-node/package.json
@@ -37,7 +37,7 @@
     "prepublishOnly": "package-check"
   },
   "dependencies": {
-    "@ceramicnetwork/http-client": "^2.3.4",
+    "@ceramicnetwork/http-client": "^2.3.5-rc.2",
     "@composedb/client": "workspace:^0.2.1",
     "express": "^4.18.1",
     "express-graphql": "^0.12.0",

--- a/packages/devtools/package.json
+++ b/packages/devtools/package.json
@@ -39,7 +39,7 @@
     "prepublishOnly": "package-check"
   },
   "dependencies": {
-    "@ceramicnetwork/stream-model": "^0.5.0",
+    "@ceramicnetwork/stream-model": "^0.5.1-rc.2",
     "@composedb/graphql-scalars": "workspace:^0.2.1",
     "@graphql-tools/schema": "^9.0.2",
     "@graphql-tools/utils": "^8.10.1",
@@ -52,8 +52,8 @@
     "uint8arrays": "^3.0.0"
   },
   "devDependencies": {
-    "@ceramicnetwork/common": "^2.6.0",
-    "@ceramicnetwork/streamid": "^2.3.3",
+    "@ceramicnetwork/common": "^2.6.1-rc.2",
+    "@ceramicnetwork/streamid": "^2.3.4-rc.0",
     "@composedb/test-schemas": "workspace:^0.2.0",
     "@composedb/types": "workspace:^0.2.1",
     "@types/jest": "^28.1.8",

--- a/packages/graphql-scalars/package.json
+++ b/packages/graphql-scalars/package.json
@@ -37,7 +37,7 @@
     "prepublishOnly": "package-check"
   },
   "dependencies": {
-    "@ceramicnetwork/streamid": "^2.3.3",
+    "@ceramicnetwork/streamid": "^2.3.4-rc.0",
     "@composedb/types": "workspace:^0.2.1",
     "graphql": "^16.5.0",
     "graphql-scalars": "^1.18.0"

--- a/packages/jest-environment-composedb/package.json
+++ b/packages/jest-environment-composedb/package.json
@@ -23,7 +23,7 @@
     "lint": "eslint index.js --fix"
   },
   "dependencies": {
-    "@ceramicnetwork/core": "^2.9.0",
+    "@ceramicnetwork/core": "^2.10.0-rc.2",
     "dids": "^3.3.0",
     "ipfs-core": "^0.15.4",
     "jest-environment-node": "^29.0.1",

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -36,8 +36,8 @@
     "prepublishOnly": "package-check"
   },
   "dependencies": {
-    "@ceramicnetwork/stream-model": "^0.5.0",
-    "@ceramicnetwork/stream-model-instance": "^0.4.1",
+    "@ceramicnetwork/stream-model": "^0.5.1-rc.2",
+    "@ceramicnetwork/stream-model-instance": "^0.4.2-rc.2",
     "dids": "^3.3.0",
     "json-schema-typed": "^8.0.1"
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -46,7 +46,7 @@ importers:
 
   examples/next-notes:
     specifiers:
-      '@ceramicnetwork/http-client': ^2.3.4
+      '@ceramicnetwork/http-client': ^2.3.5-rc.2
       '@composedb/client': workspace:^0.2.0
       '@composedb/devtools': workspace:^0.2.0
       '@composedb/devtools-node': workspace:^0.2.0
@@ -76,7 +76,7 @@ importers:
       typescript: ^4.8.2
       uint8arrays: ^3.0.0
     dependencies:
-      '@ceramicnetwork/http-client': 2.3.4
+      '@ceramicnetwork/http-client': 2.3.5-rc.2
       '@composedb/client': link:../../packages/client
       '@composedb/types': link:../../packages/types
       '@emotion/react': 11.10.0_ug65io7jkbhmo4fihdmbrh3ina
@@ -110,8 +110,8 @@ importers:
   examples/webpack-notes:
     specifiers:
       '@apollo/client': ^3.6.9
-      '@ceramicnetwork/common': ^2.5.0
-      '@ceramicnetwork/http-client': ^2.3.4
+      '@ceramicnetwork/common': ^2.6.1-rc.2
+      '@ceramicnetwork/http-client': ^2.3.5-rc.2
       '@composedb/client': workspace:^0.2.0
       '@composedb/devtools': workspace:^0.2.0
       '@composedb/devtools-node': workspace:^0.2.0
@@ -145,7 +145,7 @@ importers:
       webpack-dev-server: ^4.10.1
     dependencies:
       '@apollo/client': 3.6.9_react@18.2.0
-      '@ceramicnetwork/http-client': 2.3.4
+      '@ceramicnetwork/http-client': 2.3.5-rc.2
       '@composedb/client': link:../../packages/client
       '@composedb/types': link:../../packages/types
       '@emotion/react': 11.10.0_ug65io7jkbhmo4fihdmbrh3ina
@@ -164,7 +164,7 @@ importers:
       regenerator-runtime: 0.13.9
       uint8arrays: 3.1.0
     devDependencies:
-      '@ceramicnetwork/common': 2.5.0
+      '@ceramicnetwork/common': 2.6.1-rc.2
       '@composedb/devtools': link:../../packages/devtools
       '@composedb/devtools-node': link:../../packages/devtools-node
       '@swc/core': 1.2.244
@@ -182,13 +182,13 @@ importers:
 
   packages/cli:
     specifiers:
-      '@ceramicnetwork/3id-did-resolver': ^2.1.7
-      '@ceramicnetwork/common': ^2.5.0
-      '@ceramicnetwork/core': ^2.9.0
-      '@ceramicnetwork/http-client': ^2.3.4
-      '@ceramicnetwork/stream-model': ^0.5.0
-      '@ceramicnetwork/stream-model-instance': ^0.4.1
-      '@ceramicnetwork/streamid': ^2.3.3
+      '@ceramicnetwork/3id-did-resolver': ^2.1.8-rc.2
+      '@ceramicnetwork/common': ^2.6.1-rc.2
+      '@ceramicnetwork/core': ^2.10.0-rc.2
+      '@ceramicnetwork/http-client': ^2.3.5-rc.2
+      '@ceramicnetwork/stream-model': ^0.5.1-rc.2
+      '@ceramicnetwork/stream-model-instance': ^0.4.2-rc.2
+      '@ceramicnetwork/streamid': ^2.3.4-rc.0
       '@composedb/client': workspace:^0.2.1
       '@composedb/devtools': workspace:^0.2.1
       '@composedb/devtools-node': workspace:^0.2.1
@@ -222,11 +222,11 @@ importers:
       term-size: ^3.0.2
       uint8arrays: ^3.0.0
     dependencies:
-      '@ceramicnetwork/3id-did-resolver': 2.1.7
-      '@ceramicnetwork/http-client': 2.3.4
-      '@ceramicnetwork/stream-model': 0.5.0
-      '@ceramicnetwork/stream-model-instance': 0.4.1
-      '@ceramicnetwork/streamid': 2.3.3
+      '@ceramicnetwork/3id-did-resolver': 2.1.8-rc.2
+      '@ceramicnetwork/http-client': 2.3.5-rc.2
+      '@ceramicnetwork/stream-model': 0.5.1-rc.2
+      '@ceramicnetwork/stream-model-instance': 0.4.2-rc.2
+      '@ceramicnetwork/streamid': 2.3.4-rc.0
       '@composedb/client': link:../client
       '@composedb/devtools': link:../devtools
       '@composedb/devtools-node': link:../devtools-node
@@ -247,8 +247,8 @@ importers:
       term-size: 3.0.2
       uint8arrays: 3.1.0
     devDependencies:
-      '@ceramicnetwork/common': 2.5.0
-      '@ceramicnetwork/core': 2.9.0
+      '@ceramicnetwork/common': 2.6.1-rc.2
+      '@ceramicnetwork/core': 2.10.0-rc.2
       '@composedb/types': link:../types
       '@swc-node/register': 1.5.1
       '@types/fs-extra': 9.0.13
@@ -265,11 +265,11 @@ importers:
 
   packages/client:
     specifiers:
-      '@ceramicnetwork/common': ^2.6.0
-      '@ceramicnetwork/http-client': ^2.3.4
-      '@ceramicnetwork/stream-model': ^0.5.0
-      '@ceramicnetwork/stream-model-instance': ^0.4.1
-      '@ceramicnetwork/streamid': ^2.3.3
+      '@ceramicnetwork/common': ^2.6.1-rc.2
+      '@ceramicnetwork/http-client': ^2.3.5-rc.2
+      '@ceramicnetwork/stream-model': ^0.5.1-rc.2
+      '@ceramicnetwork/stream-model-instance': ^0.4.2-rc.2
+      '@ceramicnetwork/streamid': ^2.3.4-rc.0
       '@composedb/devtools': workspace:^0.2.1
       '@composedb/graphql-scalars': workspace:^0.2.1
       '@composedb/test-schemas': workspace:^0.2.0
@@ -280,16 +280,16 @@ importers:
       graphql-relay: ^0.10.0
       jest-environment-composedb: workspace:^0.2.0
     dependencies:
-      '@ceramicnetwork/http-client': 2.3.4
-      '@ceramicnetwork/stream-model': 0.5.0
-      '@ceramicnetwork/stream-model-instance': 0.4.1
-      '@ceramicnetwork/streamid': 2.3.3
+      '@ceramicnetwork/http-client': 2.3.5-rc.2
+      '@ceramicnetwork/stream-model': 0.5.1-rc.2
+      '@ceramicnetwork/stream-model-instance': 0.4.2-rc.2
+      '@ceramicnetwork/streamid': 2.3.4-rc.0
       '@composedb/graphql-scalars': link:../graphql-scalars
       dataloader: 2.1.0
       graphql: 16.6.0
       graphql-relay: 0.10.0_graphql@16.6.0
     devDependencies:
-      '@ceramicnetwork/common': 2.6.0
+      '@ceramicnetwork/common': 2.6.1-rc.2
       '@composedb/devtools': link:../devtools
       '@composedb/test-schemas': link:../test-schemas
       '@composedb/types': link:../types
@@ -298,9 +298,9 @@ importers:
 
   packages/devtools:
     specifiers:
-      '@ceramicnetwork/common': ^2.6.0
-      '@ceramicnetwork/stream-model': ^0.5.0
-      '@ceramicnetwork/streamid': ^2.3.3
+      '@ceramicnetwork/common': ^2.6.1-rc.2
+      '@ceramicnetwork/stream-model': ^0.5.1-rc.2
+      '@ceramicnetwork/streamid': ^2.3.4-rc.0
       '@composedb/graphql-scalars': workspace:^0.2.1
       '@composedb/test-schemas': workspace:^0.2.0
       '@composedb/types': workspace:^0.2.1
@@ -324,7 +324,7 @@ importers:
       type-fest: ^2.19.0
       uint8arrays: ^3.0.0
     dependencies:
-      '@ceramicnetwork/stream-model': 0.5.0
+      '@ceramicnetwork/stream-model': 0.5.1-rc.2
       '@composedb/graphql-scalars': link:../graphql-scalars
       '@graphql-tools/schema': 9.0.2_graphql@16.6.0
       '@graphql-tools/utils': 8.10.1_graphql@16.6.0
@@ -336,8 +336,8 @@ importers:
       type-fest: 2.19.0
       uint8arrays: 3.1.0
     devDependencies:
-      '@ceramicnetwork/common': 2.6.0
-      '@ceramicnetwork/streamid': 2.3.3
+      '@ceramicnetwork/common': 2.6.1-rc.2
+      '@ceramicnetwork/streamid': 2.3.4-rc.0
       '@composedb/test-schemas': link:../test-schemas
       '@composedb/types': link:../types
       '@types/jest': 28.1.8
@@ -353,7 +353,7 @@ importers:
 
   packages/devtools-node:
     specifiers:
-      '@ceramicnetwork/http-client': ^2.3.4
+      '@ceramicnetwork/http-client': ^2.3.5-rc.2
       '@composedb/client': workspace:^0.2.1
       '@composedb/devtools': workspace:^0.2.1
       '@composedb/types': workspace:^0.2.1
@@ -366,7 +366,7 @@ importers:
       get-port: ^6.1.2
       graphql: ^16.5.0
     dependencies:
-      '@ceramicnetwork/http-client': 2.3.4
+      '@ceramicnetwork/http-client': 2.3.5-rc.2
       '@composedb/client': link:../client
       express: 4.18.1
       express-graphql: 0.12.0_graphql@16.6.0
@@ -382,19 +382,19 @@ importers:
 
   packages/graphql-scalars:
     specifiers:
-      '@ceramicnetwork/streamid': ^2.3.3
+      '@ceramicnetwork/streamid': ^2.3.4-rc.0
       '@composedb/types': workspace:^0.2.1
       graphql: ^16.5.0
       graphql-scalars: ^1.18.0
     dependencies:
-      '@ceramicnetwork/streamid': 2.3.3
+      '@ceramicnetwork/streamid': 2.3.4-rc.0
       '@composedb/types': link:../types
       graphql: 16.6.0
       graphql-scalars: 1.18.0_graphql@16.6.0
 
   packages/jest-environment-composedb:
     specifiers:
-      '@ceramicnetwork/core': ^2.9.0
+      '@ceramicnetwork/core': ^2.10.0-rc.2
       dids: ^3.3.0
       ipfs-core: ^0.15.4
       jest-environment-node: ^29.0.1
@@ -403,7 +403,7 @@ importers:
       tmp-promise: ^3.0.3
       uint8arrays: ^3.0.0
     dependencies:
-      '@ceramicnetwork/core': 2.9.0
+      '@ceramicnetwork/core': 2.10.0-rc.2
       dids: 3.3.0
       ipfs-core: 0.15.4
       jest-environment-node: 29.0.1
@@ -417,13 +417,13 @@ importers:
 
   packages/types:
     specifiers:
-      '@ceramicnetwork/stream-model': ^0.5.0
-      '@ceramicnetwork/stream-model-instance': ^0.4.1
+      '@ceramicnetwork/stream-model': ^0.5.1-rc.2
+      '@ceramicnetwork/stream-model-instance': ^0.4.2-rc.2
       dids: ^3.3.0
       json-schema-typed: ^8.0.1
     dependencies:
-      '@ceramicnetwork/stream-model': 0.5.0
-      '@ceramicnetwork/stream-model-instance': 0.4.1
+      '@ceramicnetwork/stream-model': 0.5.1-rc.2
+      '@ceramicnetwork/stream-model-instance': 0.4.2-rc.2
       dids: 3.3.0
       json-schema-typed: 8.0.1
 
@@ -2034,12 +2034,12 @@ packages:
     resolution: {integrity: sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==}
     dev: true
 
-  /@ceramicnetwork/3id-did-resolver/2.1.7:
-    resolution: {integrity: sha512-EL2GfCnC61zFW52i3XM6PBK1L+d7eA3ZFyWmMNHH30/fwBfmC0egmU2lbaCL14NRBM3y0jAhXevayGRg0vpXMw==}
+  /@ceramicnetwork/3id-did-resolver/2.1.8-rc.2:
+    resolution: {integrity: sha512-TR7c7bQOmGtBT/pESnquiNKjbPQaKLDtEBFbeInKl+Z4+nSWVX4T0GJlxSgLyCkJfa79/HgY4s1+oZTAlMNi5A==}
     dependencies:
-      '@ceramicnetwork/common': 2.6.0
-      '@ceramicnetwork/stream-tile': 2.4.3
-      '@ceramicnetwork/streamid': 2.3.3
+      '@ceramicnetwork/common': 2.6.1-rc.2
+      '@ceramicnetwork/stream-tile': 2.4.4-rc.2
+      '@ceramicnetwork/streamid': 2.3.4-rc.0
       cross-fetch: 3.1.5
       lru_map: 0.4.1
       multiformats: 9.7.1
@@ -2048,10 +2048,10 @@ packages:
       - encoding
     dev: false
 
-  /@ceramicnetwork/blockchain-utils-linking/2.0.11:
-    resolution: {integrity: sha512-vyatJmevt5zgKJoo5Evdq3CLtQsj7k0nZmjN5mNMDhw5kMmP3AFkcJYTXi3/3TMNUUMyj6zUweDWQdiyHIaa9w==}
+  /@ceramicnetwork/blockchain-utils-linking/2.0.12-rc.0:
+    resolution: {integrity: sha512-U+dGzQvzATE56d5FR564uZfvOSxnxJeCUQwFw8bCIVgNF7GBB6Eex2S00BBuz2YSAb7eVRuaftd02lS1lfc22Q==}
     dependencies:
-      '@ceramicnetwork/streamid': 2.3.3
+      '@ceramicnetwork/streamid': 2.3.4-rc.0
       '@stablelib/random': 1.0.2
       '@stablelib/sha256': 1.0.1
       caip: 1.1.0
@@ -2061,11 +2061,11 @@ packages:
     transitivePeerDependencies:
       - encoding
 
-  /@ceramicnetwork/blockchain-utils-validation/2.0.12:
-    resolution: {integrity: sha512-EzMX5e8BNLhGIMqhhfhYgtDUa7gxErNmymQAsJ5UT3lfCyyzbJpBl8oj3Zpa6aD9/LkBVeCIxEwSiRnNrpA9Ow==}
+  /@ceramicnetwork/blockchain-utils-validation/2.0.13-rc.2:
+    resolution: {integrity: sha512-TdIrPy5O8jzV4GeyunYov0qyqJ6H1Pxh46uh0NKmapvQDSwOdsA7kpcKClWjPk29Wh52CRKWoYDMZb8/r5eESQ==}
     dependencies:
-      '@ceramicnetwork/blockchain-utils-linking': 2.0.11
-      '@ceramicnetwork/common': 2.6.0
+      '@ceramicnetwork/blockchain-utils-linking': 2.0.12-rc.0
+      '@ceramicnetwork/common': 2.6.1-rc.2
       '@ethersproject/contracts': 5.7.0
       '@ethersproject/providers': 5.7.0
       '@ethersproject/wallet': 5.7.0
@@ -2085,34 +2085,10 @@ packages:
       - encoding
       - utf-8-validate
 
-  /@ceramicnetwork/common/2.5.0:
-    resolution: {integrity: sha512-+rYZA3IbmIYSqMKEGm8JLNJcSRZlilsIH346LYhpXrKfUHor/xbtoQ6+8/0kbKFNmCz/s5t2gsY0TO1Cq3qYTw==}
+  /@ceramicnetwork/common/2.6.1-rc.2:
+    resolution: {integrity: sha512-4RxvkYwjHYk5BEw54p9My0bAlwFEz5YRlu6ruLztP+osawjCaBHrluc/uSxDySBS3y9okHFnrsPTFo/FiXsZ+w==}
     dependencies:
-      '@ceramicnetwork/streamid': 2.3.3
-      '@opentelemetry/exporter-prometheus': 0.28.0
-      '@opentelemetry/sdk-metrics-base': 0.28.0
-      '@opentelemetry/semantic-conventions': 1.6.0
-      '@stablelib/random': 1.0.2
-      caip: 1.1.0
-      ceramic-cacao: 1.4.0
-      cross-fetch: 3.1.5
-      flat: 5.0.2
-      it-first: 1.0.7
-      jet-logger: 1.2.2
-      lodash.clonedeep: 4.5.0
-      logfmt: 1.3.2
-      multiformats: 9.7.1
-      rxjs: 7.5.6
-      uint8arrays: 3.1.0
-    transitivePeerDependencies:
-      - '@opentelemetry/api'
-      - encoding
-    dev: true
-
-  /@ceramicnetwork/common/2.6.0:
-    resolution: {integrity: sha512-8xnujYalkOB5bzTVSDjyibYWOHlc5Yc8VOhauwWQWXJeHr+FiiLHdQ6O5/Hxhw+cpwf2CfEALLc9EDKvoZAlpg==}
-    dependencies:
-      '@ceramicnetwork/streamid': 2.3.3
+      '@ceramicnetwork/streamid': 2.3.4-rc.0
       '@stablelib/random': 1.0.2
       caip: 1.1.0
       ceramic-cacao: 1.4.0
@@ -2128,23 +2104,23 @@ packages:
     transitivePeerDependencies:
       - encoding
 
-  /@ceramicnetwork/core/2.9.0:
-    resolution: {integrity: sha512-cp04fZpsuqMqjZAmIvSjgOO6J0wpRTknUTuKdzCfHtAuki9HIkBLm+cTO1FimUShYQAseZEnkW5KZ3k7FB0gnQ==}
+  /@ceramicnetwork/core/2.10.0-rc.2:
+    resolution: {integrity: sha512-0ng77h0zM/DcuobUacsgIMmQYds78R1YzVpvynSWbW9PiFMkBWJJ9U2UCBsYtzwR4nPK3sZGFqGXJU0avuIHWA==}
     dependencies:
-      '@ceramicnetwork/common': 2.6.0
-      '@ceramicnetwork/ipfs-topology': 2.2.0
+      '@ceramicnetwork/common': 2.6.1-rc.2
+      '@ceramicnetwork/ipfs-topology': 2.2.1-rc.2
       '@ceramicnetwork/metrics': 0.0.3
-      '@ceramicnetwork/pinning-aggregation': 2.0.12
-      '@ceramicnetwork/pinning-ipfs-backend': 2.0.12
-      '@ceramicnetwork/stream-caip10-link': 2.2.3
-      '@ceramicnetwork/stream-caip10-link-handler': 2.1.4
-      '@ceramicnetwork/stream-model': 0.5.0
-      '@ceramicnetwork/stream-model-handler': 0.5.0
-      '@ceramicnetwork/stream-model-instance': 0.4.1
-      '@ceramicnetwork/stream-model-instance-handler': 0.6.0
-      '@ceramicnetwork/stream-tile': 2.4.3
-      '@ceramicnetwork/stream-tile-handler': 2.2.7
-      '@ceramicnetwork/streamid': 2.3.3
+      '@ceramicnetwork/pinning-aggregation': 2.0.13-rc.2
+      '@ceramicnetwork/pinning-ipfs-backend': 2.0.13-rc.2
+      '@ceramicnetwork/stream-caip10-link': 2.2.4-rc.2
+      '@ceramicnetwork/stream-caip10-link-handler': 2.1.5-rc.2
+      '@ceramicnetwork/stream-model': 0.5.1-rc.2
+      '@ceramicnetwork/stream-model-handler': 0.5.1-rc.2
+      '@ceramicnetwork/stream-model-instance': 0.4.2-rc.2
+      '@ceramicnetwork/stream-model-instance-handler': 0.6.1-rc.2
+      '@ceramicnetwork/stream-tile': 2.4.4-rc.2
+      '@ceramicnetwork/stream-tile-handler': 2.2.8-rc.2
+      '@ceramicnetwork/streamid': 2.3.4-rc.0
       '@datastructures-js/priority-queue': 6.1.2
       '@ethersproject/providers': 5.7.0
       '@ipld/dag-cbor': 7.0.3
@@ -2181,25 +2157,25 @@ packages:
       - tedious
       - utf-8-validate
 
-  /@ceramicnetwork/http-client/2.3.4:
-    resolution: {integrity: sha512-ctqGj9T+MGrjgdqatyk918FWBsRLc9R8brsUHJlqLD5XYki2Xh+jd5PFE7Ry1HLDIA60Nminli7FLSUY8zTzbw==}
+  /@ceramicnetwork/http-client/2.3.5-rc.2:
+    resolution: {integrity: sha512-7/BR2E4SyXHsfj2Nz0JyXC0rnZJYsOhBjT/dVWY/UeJvJpucE+IdKzG0p+p/n0a4yvyK82x0ddp0e3gLhhS/Wg==}
     dependencies:
-      '@ceramicnetwork/common': 2.6.0
-      '@ceramicnetwork/stream-caip10-link': 2.2.3
-      '@ceramicnetwork/stream-model': 0.5.0
-      '@ceramicnetwork/stream-model-instance': 0.4.1
-      '@ceramicnetwork/stream-tile': 2.4.3
-      '@ceramicnetwork/streamid': 2.3.3
+      '@ceramicnetwork/common': 2.6.1-rc.2
+      '@ceramicnetwork/stream-caip10-link': 2.2.4-rc.2
+      '@ceramicnetwork/stream-model': 0.5.1-rc.2
+      '@ceramicnetwork/stream-model-instance': 0.4.2-rc.2
+      '@ceramicnetwork/stream-tile': 2.4.4-rc.2
+      '@ceramicnetwork/streamid': 2.3.4-rc.0
       query-string: 7.1.1
       rxjs: 7.5.6
     transitivePeerDependencies:
       - encoding
     dev: false
 
-  /@ceramicnetwork/ipfs-topology/2.2.0:
-    resolution: {integrity: sha512-NeWEX+bCkDPMXmTtYlRffc6DLdXDBWfxKYPOEfMWgFu7tza6Ba0+ZlzMaA/JDZetnaTQiaH2vifaI3w2Ha0fnA==}
+  /@ceramicnetwork/ipfs-topology/2.2.1-rc.2:
+    resolution: {integrity: sha512-zkabiyRvDJs02GWwxIakZJ8KWGI9e31HHv/oQYQRU2aMdYF+e6VgoZd36L1ChVpDNWJtZb4XygWqEg6T1hLJRQ==}
     dependencies:
-      '@ceramicnetwork/common': 2.6.0
+      '@ceramicnetwork/common': 2.6.1-rc.2
       cross-fetch: 3.1.5
     transitivePeerDependencies:
       - encoding
@@ -2214,14 +2190,14 @@ packages:
     transitivePeerDependencies:
       - '@opentelemetry/api'
 
-  /@ceramicnetwork/pinning-aggregation/2.0.12:
-    resolution: {integrity: sha512-1Eq7GuA/1qrUOsSOaRd1Ba7beCJI/KcQsOnbAyOX9c+bhDrJld7kQIoI9cCl6jZ4rVqEcQkBcFXG3S1Intby4A==}
+  /@ceramicnetwork/pinning-aggregation/2.0.13-rc.2:
+    resolution: {integrity: sha512-ajAhyeTl+3kqSqymrh+yXu4+AZssdBjIq8dsKL+VAnGHJcO6oKzNjLgqmyNlKht58RY03puPxe8ULJpapWai5w==}
     dependencies:
       '@stablelib/sha256': 1.0.1
       uint8arrays: 3.1.0
 
-  /@ceramicnetwork/pinning-ipfs-backend/2.0.12:
-    resolution: {integrity: sha512-uzaslneThE31PoG2YTU7j7uZEF12j3u8gUGg5gJNdtlrSrgZ9ojqe9nMGRCHPkzW8xelzTafDN0nSSOo64XisA==}
+  /@ceramicnetwork/pinning-ipfs-backend/2.0.13-rc.2:
+    resolution: {integrity: sha512-H8ty6/TAL5dcNH2Yih4w2AhORCZKzZ6YneM0Iw+CJZrIIr94oJHB/N0npo+hbd+YowcNRBLjbbUiTc49bv9xKA==}
     dependencies:
       '@stablelib/sha256': 1.0.1
       ipfs-http-client: 55.0.0
@@ -2230,35 +2206,35 @@ packages:
       - node-fetch
       - supports-color
 
-  /@ceramicnetwork/stream-caip10-link-handler/2.1.4:
-    resolution: {integrity: sha512-fTmLW7733yOt5l4VTpZBDLLfDNEUoAuSvuz9PFltHxAL4qp5zd0MDZQP2qUN+Whbp/sKnXtpSn22gWi7zUBinA==}
+  /@ceramicnetwork/stream-caip10-link-handler/2.1.5-rc.2:
+    resolution: {integrity: sha512-7ULGx44Zf8bTDC2PTVZ5p/thCBW/U/TAIF4Lz5hBPLVv0WD/tLUtRbNenOsU3ytnxLbGBIaYrj1PW17g57Cwmg==}
     dependencies:
-      '@ceramicnetwork/blockchain-utils-validation': 2.0.12
-      '@ceramicnetwork/common': 2.6.0
-      '@ceramicnetwork/stream-caip10-link': 2.2.3
+      '@ceramicnetwork/blockchain-utils-validation': 2.0.13-rc.2
+      '@ceramicnetwork/common': 2.6.1-rc.2
+      '@ceramicnetwork/stream-caip10-link': 2.2.4-rc.2
     transitivePeerDependencies:
       - bufferutil
       - debug
       - encoding
       - utf-8-validate
 
-  /@ceramicnetwork/stream-caip10-link/2.2.3:
-    resolution: {integrity: sha512-IVt4bqLhcN7DyADTrZyTkHNEPCxUZKHUAaVQN3zxqV0hEgCYX4aMgZ+dP0t2cePZ9KKXyqT86Bu8AZ5Iw3/1zA==}
+  /@ceramicnetwork/stream-caip10-link/2.2.4-rc.2:
+    resolution: {integrity: sha512-RAg11RcVZuzPHq4bpG5f6P0ZmRiyXDXi4fS4g0Z86PJd8oWP+RmiPUg9LY1o30uBfuQ9aJbtJRyerH1ZxoeWWg==}
     dependencies:
-      '@ceramicnetwork/common': 2.6.0
-      '@ceramicnetwork/streamid': 2.3.3
+      '@ceramicnetwork/common': 2.6.1-rc.2
+      '@ceramicnetwork/streamid': 2.3.4-rc.0
       caip: 1.1.0
       did-resolver: 3.2.2
       lodash.clonedeep: 4.5.0
     transitivePeerDependencies:
       - encoding
 
-  /@ceramicnetwork/stream-model-handler/0.5.0:
-    resolution: {integrity: sha512-q9obgRwRvUxtSfBLEMpT5+g1z1Efn9uccl+Ro/tyEW2QwjSuVcu5vmYB5RA+iErkz2GtMCKKncbXHtmNeGhRJQ==}
+  /@ceramicnetwork/stream-model-handler/0.5.1-rc.2:
+    resolution: {integrity: sha512-c2spnpYvB4L5WugF5xmEKYvAbyYL5hW5wA6v3qgf5KWNtLjUG7qSn+5ibIB/N3w8yRz/25gNFPW5TzGIKhw17Q==}
     dependencies:
-      '@ceramicnetwork/common': 2.6.0
-      '@ceramicnetwork/stream-model': 0.5.0
-      '@ceramicnetwork/streamid': 2.3.3
+      '@ceramicnetwork/common': 2.6.1-rc.2
+      '@ceramicnetwork/stream-model': 0.5.1-rc.2
+      '@ceramicnetwork/streamid': 2.3.4-rc.0
       ajv: 8.11.0
       ajv-formats: 2.1.1
       fast-json-patch: 3.1.1
@@ -2267,12 +2243,12 @@ packages:
     transitivePeerDependencies:
       - encoding
 
-  /@ceramicnetwork/stream-model-instance-handler/0.6.0:
-    resolution: {integrity: sha512-/UnEvBVaRrufWfK+Ci/1jtgn1pnk5vb8zqszpmJRcDgUKNKWlOh/O6ARpSuOJgo1yks7yjREAVnugh2bhzitFA==}
+  /@ceramicnetwork/stream-model-instance-handler/0.6.1-rc.2:
+    resolution: {integrity: sha512-r01zCEjrhc2PzQMpPK+oRVddfV99rAtURxVAvJAyAe9ybE6qX489Jv7Ly4/+svyUGubq9s22TtO3ELOJIB6Hcg==}
     dependencies:
-      '@ceramicnetwork/common': 2.6.0
-      '@ceramicnetwork/stream-model-instance': 0.4.1
-      '@ceramicnetwork/streamid': 2.3.3
+      '@ceramicnetwork/common': 2.6.1-rc.2
+      '@ceramicnetwork/stream-model-instance': 0.4.2-rc.2
+      '@ceramicnetwork/streamid': 2.3.4-rc.0
       ajv: 8.11.0
       ajv-formats: 2.1.1
       fast-json-patch: 3.1.1
@@ -2281,11 +2257,11 @@ packages:
     transitivePeerDependencies:
       - encoding
 
-  /@ceramicnetwork/stream-model-instance/0.4.1:
-    resolution: {integrity: sha512-OpoGjQC1MnnZu/dhX224LF17WbRQExjRORh1O30mpKI7LDkOhxGntrbMw4I2MRsuA6JnsNy05GBa9n8/0P/rng==}
+  /@ceramicnetwork/stream-model-instance/0.4.2-rc.2:
+    resolution: {integrity: sha512-LDekGgUS4ODvA1x5XOl/ecGOjkIeX6xZ6sFexsSEScPvesO7sIzOcMybmb+wvc9SmfNzMfD5kX8xtmGv/GXTLA==}
     dependencies:
-      '@ceramicnetwork/common': 2.6.0
-      '@ceramicnetwork/streamid': 2.3.3
+      '@ceramicnetwork/common': 2.6.1-rc.2
+      '@ceramicnetwork/streamid': 2.3.4-rc.0
       '@ipld/dag-cbor': 7.0.3
       '@stablelib/random': 1.0.2
       fast-json-patch: 3.1.1
@@ -2293,11 +2269,11 @@ packages:
     transitivePeerDependencies:
       - encoding
 
-  /@ceramicnetwork/stream-model/0.5.0:
-    resolution: {integrity: sha512-0B3yDBFyOGWrUa7XuGIqDJF3G2kOREF+6qa1UdDCScoqhvZT8JUlAs89sZcs6gfeGSR/HXeztzYfJGvPvKuMTQ==}
+  /@ceramicnetwork/stream-model/0.5.1-rc.2:
+    resolution: {integrity: sha512-a5TePSoNfpFOUWMTzl3gQd3KlZwwdq3uEerbTxb1TD77FIhrcl/iprMbi5w/XUG39bY1VQOTbQ4OSbX1Gxwblw==}
     dependencies:
-      '@ceramicnetwork/common': 2.6.0
-      '@ceramicnetwork/streamid': 2.3.3
+      '@ceramicnetwork/common': 2.6.1-rc.2
+      '@ceramicnetwork/streamid': 2.3.4-rc.0
       '@ipld/dag-cbor': 7.0.3
       '@stablelib/random': 1.0.2
       fast-json-patch: 3.1.1
@@ -2308,11 +2284,11 @@ packages:
     transitivePeerDependencies:
       - encoding
 
-  /@ceramicnetwork/stream-tile-handler/2.2.7:
-    resolution: {integrity: sha512-gRSlBnxjOj6X4/gF2JGFR6JwOuYcOXzsjEeFKXwX+BtKZAxe3vs2Alj2w9qCisq/DOIrp77MfRhHyMwE42ycUg==}
+  /@ceramicnetwork/stream-tile-handler/2.2.8-rc.2:
+    resolution: {integrity: sha512-LFlib8FbPKYmg3rkNOQb5shG/GK9pCtHFkF034WwSnV8T91I+8nBEVMf7IClUdkqXcdICxnF/StWcDUF3fTYdA==}
     dependencies:
-      '@ceramicnetwork/common': 2.6.0
-      '@ceramicnetwork/stream-tile': 2.4.3
+      '@ceramicnetwork/common': 2.6.1-rc.2
+      '@ceramicnetwork/stream-tile': 2.4.4-rc.2
       ajv: 8.11.0
       ajv-formats: 2.1.1
       fast-json-patch: 3.1.1
@@ -2321,11 +2297,11 @@ packages:
     transitivePeerDependencies:
       - encoding
 
-  /@ceramicnetwork/stream-tile/2.4.3:
-    resolution: {integrity: sha512-9b3NPEeh2sFQTpbpLXMP6pXK5maafDicmTMRwipCsB+JZ+bW/Q6xtXtGHq8bqFawmfRR5JVBJzOkqUmZNUu9Pw==}
+  /@ceramicnetwork/stream-tile/2.4.4-rc.2:
+    resolution: {integrity: sha512-eEPAntKHs2RIlqpumF4eg6WZHROuK09BJSQWcnYWWwSH7gqlGqMNufeLqWsQtV+UvZFs5z9Ram3gI4LcG4jlZQ==}
     dependencies:
-      '@ceramicnetwork/common': 2.6.0
-      '@ceramicnetwork/streamid': 2.3.3
+      '@ceramicnetwork/common': 2.6.1-rc.2
+      '@ceramicnetwork/streamid': 2.3.4-rc.0
       '@ipld/dag-cbor': 7.0.3
       '@stablelib/random': 1.0.2
       fast-json-patch: 3.1.1
@@ -2334,8 +2310,8 @@ packages:
     transitivePeerDependencies:
       - encoding
 
-  /@ceramicnetwork/streamid/2.3.3:
-    resolution: {integrity: sha512-YVxc7uGcb97IVQfBo3VHJ8l7ELN6a6Rb6cxKT9Ko7JutPerqBbyZUdsdahLIuNP2wBN8MHR8MpHh/iVbLe81IA==}
+  /@ceramicnetwork/streamid/2.3.4-rc.0:
+    resolution: {integrity: sha512-lVlYa4SX4gJhraMXGyBo/5yqnDXdJSqiVHNx2tXnxQbpORswScu/Knq6lrsAWgX05mwhbTR6GMoNwyn30Dh5Og==}
     dependencies:
       '@ipld/dag-cbor': 7.0.3
       multiformats: 9.7.1
@@ -5773,6 +5749,7 @@ packages:
   /@opentelemetry/sdk-metrics-base/0.28.0:
     resolution: {integrity: sha512-PFjk9+WWU6Y51ZjxClnPW1rzTtcT79pR1FTiFjTsNmKSG0zU3qvUHAoTo0+jvvrO0Djihj7AE+iIG2xLWY4GNQ==}
     engines: {node: '>=8.12.0'}
+    deprecated: Please use @opentelemetry/sdk-metrics
     peerDependencies:
       '@opentelemetry/api': ^1.0.0
     dependencies:


### PR DESCRIPTION
# Updated ceramic deps and updated the /client and /cli packages to accommodate null stream states returned by the queryAPI

## Description

In the latest RCs of http-client and common the change was introduced that make it possible for the queryAPI to return null nodes in paginated responses. This PR updates the /cli and /client packages to accomodate that change.

Didn't write any additional tests for that. Can do it in this or in the next PR, depending on the reviews.

## How Has This Been Tested?

Describe the tests that you ran to verify your changes. Provide instructions for reproduction.

- [X] Ran all the existing tests
- [X] Manually tested the case when a model requested from index is missing from the state store:
1. Started the ceramic daemon
2. Used composedb cli to create a model from composite SDL definition
3. Stopped the ceramic daemon
4. Deleted the statestore dir used by the ceramic daemon
5. Started the ceramic daemon again
6. Tried to list the model
```
☁  cli [chore/version-bump] node bin/run.js model:list --indexer-url=http://localhost:7007
{"id":"<MISSING!!>","name":"<MISSING!!>","description":"<MISSING!!>"}

✔ Loading models... Done
```


## Definition of Done

Before submitting this PR, please make sure:

- [X] The work addresses the description and outcomes in the issue
- [] I have added relevant tests for new or updated functionality
- [X] My code follows conventions, is well commented, and easy to understand
- [X] My code builds and tests pass without any errors or warnings
- [X] I have tagged the relevant reviewers
