### PR TITLE
Make sure that the button prompt is displayed when necessary in model…

### DIFF
--- a/packages/cli/src/commands/model/list.ts
+++ b/packages/cli/src/commands/model/list.ts
@@ -58,6 +58,7 @@ export default class ModelList extends BaseCommand<ModelListFlags> {
       this.displayPartialDefinitions(this.fetchedFields)
 
       while (this.lastLoadedPageInfo?.hasNextPage) {
+        this.spinner.stop()
         await CliUx.ux.anykey('Press any key to load more models')
         this.spinner.start('Loading models...')
         const nextPage: Page<StreamState> = await ceramicIndexer.index.queryIndex({


### PR DESCRIPTION
# Make sure that the button prompt is displayed when necessary in model:list command

## Description

The prompt was there in the code (using `CliUx`), but turns out it didn't work well with `Ora` (which we also use to display the spinner info).

Fixed this by stopping the spinner before showing the `CliUx` prompt and starting it again after a button is pressed.

## How Has This Been Tested?

Describe the tests that you ran to verify your changes. Provide instructions for reproduction.

- [X] Tested manually:
* before: https://streamable.com/47c3xx
* after: https://streamable.com/nbmyj1

## Definition of Done

Before submitting this PR, please make sure:

- [X] The work addresses the description and outcomes in the issue
- [X] My code follows conventions, is well commented, and easy to understand
- [X] My code builds and tests pass without any errors or warnings
- [X] I have tagged the relevant reviewers

