### PR TITLE
Request new models to be indexed in composite:deploy when composite is read from disk

### DIFF
--- a/packages/cli/src/commands/composite/deploy.ts
+++ b/packages/cli/src/commands/composite/deploy.ts
@@ -25,7 +25,7 @@ export default class CompositeDeploy extends Command<
         const definition = JSON.parse(this.stdin) as EncodedCompositeDefinition
         composite = await Composite.fromJSON({ ceramic: this.ceramic, definition, index: true })
       } else if (this.args.compositePath !== undefined) {
-        composite = await readEncodedComposite(this.ceramic, this.args.compositePath)
+        composite = await readEncodedComposite(this.ceramic, this.args.compositePath, true)
       } else {
         this.spinner.fail(
           'You need to pass the composite definition either in stdin or as the compositePath param'

--- a/packages/devtools-node/src/fs.ts
+++ b/packages/devtools-node/src/fs.ts
@@ -35,12 +35,13 @@ export async function createComposite(ceramic: CeramicClient, path: PathInput): 
  */
 export async function readEncodedComposite(
   ceramic: CeramicClient | string,
-  path: PathInput
+  path: PathInput,
+  index?: boolean
 ): Promise<Composite> {
   const client = typeof ceramic === 'string' ? new CeramicClient(ceramic) : ceramic
   const file = getFilePath(path)
   const definition = (await readJSON(file)) as EncodedCompositeDefinition
-  return Composite.fromJSON({ ceramic: client, definition })
+  return Composite.fromJSON({ ceramic: client, definition: definition, index: index })
 }
 
 /**


### PR DESCRIPTION
Request new models to be indexed in composite:deploy when encoded composite is read from disk

We should write a test for this.

## How Has This Been Tested?

Describe the tests that you ran to verify your changes. Provide instructions for reproduction.

- [X] Tests pass

## Definition of Done

Before submitting this PR, please make sure:

- [X] The work addresses the description and outcomes in the issue

