### PR TITLE
Replace version in installation page for v0.3

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -3,7 +3,7 @@
   "version": "0.3.0",
   "author": "3Box Labs",
   "license": "(Apache-2.0 OR MIT)",
-  "homepage": "https://github.com/ceramicstudio/js-composedb#readme",
+  "homepage": "https://composedb.js.org",
   "keywords": [
     "ceramic",
     "composedb",

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -3,7 +3,7 @@
   "version": "0.3.0",
   "author": "3Box Labs",
   "license": "(Apache-2.0 OR MIT)",
-  "homepage": "https://github.com/ceramicstudio/js-composedb#readme",
+  "homepage": "https://composedb.js.org",
   "keywords": [
     "ceramic",
     "composedb",

--- a/packages/devtools-node/package.json
+++ b/packages/devtools-node/package.json
@@ -3,7 +3,7 @@
   "version": "0.3.0",
   "author": "3Box Labs",
   "license": "(Apache-2.0 OR MIT)",
-  "homepage": "https://github.com/ceramicstudio/js-composedb#readme",
+  "homepage": "https://composedb.js.org",
   "keywords": [
     "ceramic",
     "composedb",

--- a/packages/devtools/package.json
+++ b/packages/devtools/package.json
@@ -3,7 +3,7 @@
   "version": "0.3.0",
   "author": "3Box Labs",
   "license": "(Apache-2.0 OR MIT)",
-  "homepage": "https://github.com/ceramicstudio/js-composedb#readme",
+  "homepage": "https://composedb.js.org",
   "keywords": [
     "ceramic",
     "composedb",

--- a/packages/graphql-scalars/package.json
+++ b/packages/graphql-scalars/package.json
@@ -3,7 +3,7 @@
   "version": "0.3.0",
   "author": "3Box Labs",
   "license": "(Apache-2.0 OR MIT)",
-  "homepage": "https://github.com/ceramicstudio/js-composedb#readme",
+  "homepage": "https://composedb.js.org",
   "keywords": [
     "ceramic",
     "composedb",

--- a/packages/jest-environment-composedb/package.json
+++ b/packages/jest-environment-composedb/package.json
@@ -5,7 +5,7 @@
   "description": "ComposeDB environment for Jest",
   "author": "3Box Labs",
   "license": "(Apache-2.0 OR MIT)",
-  "homepage": "https://github.com/ceramicstudio/js-composedb#readme",
+  "homepage": "https://composedb.js.org",
   "keywords": [
     "jest",
     "ceramic",

--- a/packages/test-schemas/package.json
+++ b/packages/test-schemas/package.json
@@ -4,7 +4,7 @@
   "version": "0.3.0",
   "author": "3Box Labs",
   "license": "(Apache-2.0 OR MIT)",
-  "homepage": "https://github.com/ceramicstudio/js-composedb#readme",
+  "homepage": "https://composedb.js.org",
   "keywords": [
     "ceramic",
     "composedb"

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -3,7 +3,7 @@
   "version": "0.3.0",
   "author": "3Box Labs",
   "license": "(Apache-2.0 OR MIT)",
-  "homepage": "https://github.com/ceramicstudio/js-composedb#readme",
+  "homepage": "https://composedb.js.org",
   "keywords": [
     "ceramic",
     "composedb"

--- a/website/versioned_docs/version-0.3.x/installation.mdx
+++ b/website/versioned_docs/version-0.3.x/installation.mdx
@@ -34,14 +34,14 @@ The CLI provides commands for the most common flows, while the libraries can be 
   <TabItem value="npm">
 
 ```sh
-npm install --location=global @composedb/cli@next
+npm install --location=global @composedb/cli@^0.3.0
 ```
 
   </TabItem>
   <TabItem value="pnpm">
 
 ```sh
-pnpm add -g @composedb/cli@next
+pnpm add -g @composedb/cli@^0.3.0
 ```
 
   </TabItem>
@@ -54,7 +54,7 @@ Global packages are only supported for yarn 2.x and older. For yarn 3.x and newe
 :::
 
 ```sh
-yarn add -g @composedb/cli@next
+yarn add -g @composedb/cli@^0.3.0
 ```
 
   </TabItem>
@@ -75,21 +75,21 @@ ComposeDB exposes two complementary development libraries: [`@composedb/devtools
   <TabItem value="npm">
 
 ```sh
-npm install -D @composedb/devtools@next @composedb/devtools-node@next
+npm install -D @composedb/devtools@^0.3.0 @composedb/devtools-node@^0.3.0
 ```
 
   </TabItem>
   <TabItem value="pnpm">
 
 ```sh
-pnpm add -D @composedb/devtools@next @composedb/devtools-node@next
+pnpm add -D @composedb/devtools@^0.3.0 @composedb/devtools-node@^0.3.0
 ```
 
   </TabItem>
   <TabItem value="yarn">
 
 ```sh
-yarn add -D @composedb/devtools@next @composedb/devtools-node@next
+yarn add -D @composedb/devtools@^0.3.0 @composedb/devtools-node@^0.3.0
 ```
 
   </TabItem>
@@ -110,21 +110,21 @@ The [`@composedb/client`](./api/modules/client.md) package exposes the primary A
   <TabItem value="npm">
 
 ```sh
-npm install @composedb/client@next
+npm install @composedb/client@^0.3.0
 ```
 
   </TabItem>
   <TabItem value="pnpm">
 
 ```sh
-pnpm add @composedb/client@next
+pnpm add @composedb/client@^0.3.0
 ```
 
   </TabItem>
   <TabItem value="yarn">
 
 ```sh
-yarn add @composedb/client@next
+yarn add @composedb/client@^0.3.0
 ```
 
   </TabItem>
@@ -145,21 +145,21 @@ You may need to install the `@composedb/types` package used by the different lib
   <TabItem value="npm">
 
 ```sh
-npm install -D @composedb/types@next
+npm install -D @composedb/types@^0.3.0
 ```
 
   </TabItem>
   <TabItem value="pnpm">
 
 ```sh
-pnpm add -D @composedb/types@next
+pnpm add -D @composedb/types@^0.3.0
 ```
 
   </TabItem>
   <TabItem value="yarn">
 
 ```sh
-yarn add -D @composedb/types@next
+yarn add -D @composedb/types@^0.3.0
 ```
 
   </TabItem>


### PR DESCRIPTION
Also replaces the `homepage` value in `package.json` files to point to the docs rather than GitHub.