### PR TITLE
Consistent and user-friendly message when stopping model load manually

### DIFF
--- a/packages/cli/src/commands/model/list.ts
+++ b/packages/cli/src/commands/model/list.ts
@@ -60,8 +60,8 @@ export default class ModelList extends BaseCommand<ModelListFlags> {
       while (this.lastLoadedPageInfo?.hasNextPage) {
         this.spinner.stop()
         await this.anykeyWithFriendlyExit(
-          'Press any key to load more models',
-          'You stopped the model loading manually'
+          'Press ctrl+c or q to quit. Press any other key to continue loading models.',
+          'Stopped loading models due to user input'
         )
         this.spinner.start('Loading models...')
         const nextPage: Page<StreamState | null> = await ceramicIndexer.index.query({


### PR DESCRIPTION
# Consistent and user-friendly message when stopping model load after a page is loaded

## How Has This Been Tested?

Describe the tests that you ran to verify your changes. Provide instructions for reproduction.

- [X] Manually tested that the UX for stopping the command is the same for ctrl+c and q press:

<img width="1728" alt="Screenshot 2022-10-20 at 11 35 22" src="https://user-images.githubusercontent.com/209466/196941372-38fa0216-60ee-4259-a40b-3f3545987502.png">

## Definition of Done

Before submitting this PR, please make sure:

- [X] The work addresses the description and outcomes in the issue
- [X] My code follows conventions, is well commented, and easy to understand
- [X] My code builds and tests pass without any errors or warnings
- [X] I have tagged the relevant reviewers

