### PR TITLE
fix: implement temporary schema definition to support datetime scalars

### DIFF
--- a/packages/graphql-scalars/src/datetime.ts
+++ b/packages/graphql-scalars/src/datetime.ts
@@ -66,7 +66,7 @@ export const DateTime = new GraphQLScalarType({
   name: 'DateTime',
   description:
     'A date-time string at UTC, such as 2007-12-03T10:15:30Z, ' +
-    'compliant with the date-time format outlined in section 5.6 of ' +
+    'compliant with the `date-time` format outlined in section 5.6 of ' +
     'the RFC 3339 profile of the ISO 8601 standard for representation ' +
     'of dates and times using the Gregorian calendar.',
   serialize: (dateString) => {

--- a/packages/graphql-scalars/src/datetime.ts
+++ b/packages/graphql-scalars/src/datetime.ts
@@ -1,0 +1,100 @@
+//@TODO Remove this file when https://github.com/Urigo/graphql-scalars/pull/1641 is merged
+
+import { GraphQLScalarType, Kind } from 'graphql'
+
+function validateTime(time: string): boolean {
+  time = time?.toUpperCase()
+  const TIME_REGEX =
+    /^([01][0-9]|2[0-3]):([0-5][0-9]):([0-5][0-9])(\.\d{1,})?(([Z])|([+|-]([01][0-9]|2[0-3]):[0-5][0-9]))$/
+  return TIME_REGEX.test(time)
+}
+
+function validateDate(date: string): boolean {
+  const RFC_3339_REGEX = /^(\d{4}-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01]))$/
+  if (!RFC_3339_REGEX.test(date)) {
+    return false
+  }
+  // Verify the correct number of days for
+  // the month contained in the date-string.
+  const year = Number(date.substr(0, 4))
+  const month = Number(date.substr(5, 2))
+  const day = Number(date.substr(8, 2))
+  switch (month) {
+    case 2: // February
+      if (((year % 4 === 0 && year % 100 !== 0) || year % 400 === 0) && day > 29) {
+        return false
+      } else if (((year % 4 === 0 && year % 100 !== 0) || year % 400 === 0) && day > 28) {
+        return false
+      }
+      return true
+    case 4: // April
+    case 6: // June
+    case 9: // September
+    case 11: // November
+      if (day > 30) {
+        return false
+      }
+      break
+  }
+  return true
+}
+
+function validateDateTime(input: string): boolean {
+  input = input?.toUpperCase()
+  const RFC_3339_REGEX =
+    /^(\d{4}-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01])T([01][0-9]|2[0-3]):([0-5][0-9]):([0-5][0-9]|60))(\.\d{1,})?(([Z])|([+|-]([01][0-9]|2[0-3]):[0-5][0-9]))$/
+
+  // Validate the structure of the date-string
+  if (!RFC_3339_REGEX.test(input)) {
+    return false
+  }
+
+  // Check if it is a correct date using the javascript Date parse() method.
+  const time = Date.parse(input)
+  if (time !== time) {
+      // eslint-disable-line
+    return false
+  }
+  // Split the date-time-string up into the string-date and time-string part.
+  // and check whether these parts are RFC 3339 compliant.
+  const index = input.indexOf('T')
+  const dateString = input.substr(0, index)
+  const timeString = input.substr(index + 1)
+  return validateDate(dateString) && validateTime(timeString)
+}
+
+export const DateTime = new GraphQLScalarType({
+  name: 'DateTime',
+  description:
+    'A date-time string at UTC, such as 2007-12-03T10:15:30Z, ' +
+    'compliant with the date-time format outlined in section 5.6 of ' +
+    'the RFC 3339 profile of the ISO 8601 standard for representation ' +
+    'of dates and times using the Gregorian calendar.',
+  serialize: (dateString) => {
+    if (typeof dateString === 'string' && validateDateTime(dateString)) {
+      if (dateString.indexOf('Z') !== -1) {
+        return dateString
+      } else
+        throw new TypeError(`DateTime string must be formatted to UTC time  ${String(dateString)}.`)
+    } else
+      throw new TypeError(
+        `DateTime cannot represent an invalid date-time-string  ${String(dateString)}.`
+      )
+  },
+  parseValue: (value) => {
+    if (typeof value === 'string' && validateDateTime(value)) {
+      return value
+    } else
+      throw new TypeError(`DateTime cannot represent an invalid date-time-string ${String(value)}.`)
+  },
+  parseLiteral: (ast) => {
+    if (ast.kind !== Kind.STRING) {
+      throw new TypeError('DateTime cannot represent non string or Date type')
+    }
+    const { value } = ast
+    if (validateDateTime(value)) {
+      return value
+    }
+    throw new TypeError(`DateTime cannot represent an invalid date-time-string ${String(value)}.`)
+  },
+})

--- a/packages/graphql-scalars/src/datetime.ts
+++ b/packages/graphql-scalars/src/datetime.ts
@@ -51,8 +51,7 @@ function validateDateTime(input: string): boolean {
 
   // Check if it is a correct date using the javascript Date parse() method.
   const time = Date.parse(input)
-  if (time !== time) {
-      // eslint-disable-line
+  if (Number.isNaN(time)) {
     return false
   }
   // Split the date-time-string up into the string-date and time-string part.
@@ -75,10 +74,10 @@ export const DateTime = new GraphQLScalarType({
       if (dateString.indexOf('Z') !== -1) {
         return dateString
       } else
-        throw new TypeError(`DateTime string must be formatted to UTC time  ${String(dateString)}.`)
+        throw new TypeError(`DateTime string must be formatted to UTC time ${String(dateString)}.`)
     } else
       throw new TypeError(
-        `DateTime cannot represent an invalid date-time-string  ${String(dateString)}.`
+        `DateTime cannot represent an invalid date-time-string ${String(dateString)}.`
       )
   },
   parseValue: (value) => {
@@ -96,5 +95,12 @@ export const DateTime = new GraphQLScalarType({
       return value
     }
     throw new TypeError(`DateTime cannot represent an invalid date-time-string ${String(value)}.`)
+  },
+  extensions: {
+    codegenScalarType: 'Date | string',
+    jsonSchema: {
+      type: 'string',
+      format: 'date-time',
+    },
   },
 })

--- a/packages/graphql-scalars/src/datetime.ts
+++ b/packages/graphql-scalars/src/datetime.ts
@@ -97,7 +97,7 @@ export const DateTime = new GraphQLScalarType({
     throw new TypeError(`DateTime cannot represent an invalid date-time-string ${String(value)}.`)
   },
   extensions: {
-    codegenScalarType: 'Date | string',
+    codegenScalarType: 'string',
     jsonSchema: {
       type: 'string',
       format: 'date-time',

--- a/packages/graphql-scalars/src/index.ts
+++ b/packages/graphql-scalars/src/index.ts
@@ -10,17 +10,21 @@ import {
 import {
   GraphQLCountryCode,
   GraphQLDate,
-  GraphQLDateTime,
+  //GraphQLDateTime,
   GraphQLDID,
   GraphQLTime,
 } from 'graphql-scalars'
 
 import { CeramicCommitID, CeramicStreamID } from './ceramic.js'
 
+//@TODO Remove these imports when https://github.com/Urigo/graphql-scalars/pull/1641 is merged
+import { DateTime as GraphQLDateTime } from './datetime.js'
+export { DateTime as GraphQLDateTime } from './datetime.js'
+
 export {
   GraphQLCountryCode,
   GraphQLDate,
-  GraphQLDateTime,
+  //GraphQLDateTime,
   GraphQLDID,
   GraphQLTime,
 } from 'graphql-scalars'


### PR DESCRIPTION
# Ensure DateTime scalar inputs are converted to string - #53 

## Description
This is meant to be a temporary solution to enable datetime scalar types in Ceramic models while [this pull request](https://github.com/Urigo/graphql-scalars/pull/1641) is in review (as there has been no activity for some time.)

This change introduces a custom datetime scalar definition in a new file which is meant to be deleted after the solution is merged into the [graphql-scalars package](https://www.npmjs.com/package/graphql-scalars)

This schema definition is essentially a simplified copy of the logic defined in the [graphql-scalars package](https://github.com/Urigo/graphql-scalars/blob/master/src/scalars/iso-date/DateTime.ts).

It purposely kept minimal and therefore only ISO strings in UTC time are supported - as per the [documentation](https://composedb.js.org/docs/0.3.x/guides/creating-composites/scalars#datetime)

Passing in Unix timestamp or JS date object will throw an error.

## How Has This Been Tested?
Describe the tests that you ran to verify your changes. Provide instructions for reproduction.

Currently creating documents with a datetime scalar field will throw [this error](https://forum.ceramic.network/t/cbor-encode-error-unsupported-type-date-when-trying-to-create-composedb-document/360/3)

With this change, I was able to upload datetime scalar values without issue

IDs: 
- kjzl6kcym7w8y5f7jspauwxecxeuzrri0rigwwl5h7x8i9ebhmh7hi2thxmksx0
- kjzl6kcym7w8y60p5d46t282vvl4b8t4pkfk1364rlhbxtqhb71i2rtsckvqrvb
- kjzl6kcym7w8y5u9ktpponjvo0jh0pjl54tc9tx0pl3ayupzxaamdb7vpyduc0y

Model: kjzl6hvfrbw6c65z7bpyak6mgz9maadbucil8sey0lkuy9ebiinbjl0vd9ygal4

_**Let me know if/what additional testing is needed**_

## Definition of Done

Before submitting this PR, please make sure:

- [x] The work addresses the description and outcomes in the issue
- [ ] I have added relevant tests for new or updated functionality
- [x] My code follows conventions, is well commented, and easy to understand
- [x] My code builds and tests pass without any errors or warnings
- [x] I have tagged the relevant reviewers
- [ ] I have updated the READMEs of affected packages
- [ ] I have made corresponding changes to the documentation
- [x] The changes have been communicated to interested parties
