### PR TITLE
Add preview path for docs

### DIFF
--- a/website/README.md
+++ b/website/README.md
@@ -1,41 +1,26 @@
 # Website
 
-This website is built using [Docusaurus 2](https://docusaurus.io/), a modern static website generator.
-
-### Installation
-
-```
-$ yarn
-```
+This website is built using [Docusaurus 2](https://docusaurus.io/).
 
 ### Local Development
 
 ```
-$ yarn start
+pnpm start
 ```
 
-This command starts a local development server and opens up a browser window. Most changes are reflected live without having to restart the server.
+This command starts a local development server and opens up a browser window.
+Most changes are reflected live without having to restart the server.
 
 ### Build
 
 ```
-$ yarn build
+pnpm build
 ```
 
-This command generates static content into the `build` directory and can be served using any static contents hosting service.
+This command generates static content into the `build` directory and can be
+served using any static contents hosting service.
 
 ### Deployment
 
-Using SSH:
-
-```
-$ USE_SSH=true yarn deploy
-```
-
-Not using SSH:
-
-```
-$ GIT_USER=<Your GitHub username> yarn deploy
-```
-
-If you are using GitHub pages for hosting, this command is a convenient way to build the website and push to the `gh-pages` branch.
+The website is automatically deployed by a GitHub action on commits to the
+`main` branch.

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -29,14 +29,14 @@ const config = {
       ({
         docs: {
           sidebarPath: require.resolve('./sidebars.js'),
-          includeCurrentVersion: false,
+          includeCurrentVersion: true,
           lastVersion: '0.3.x',
           versions: {
-            // current: {
-            //   banner: 'unreleased',
-            //   label: 'Next 🚧',
-            //   path: 'next',
-            // },
+            current: {
+              banner: 'unreleased',
+              label: 'Preview',
+              path: 'preview',
+            },
             '0.3.x': {
               label: '0.3.x',
               path: '0.3.x',


### PR DESCRIPTION
Following discussion with @3avi, setting up docs changes under the `preview` path to avoid breaking changes to v0.3 pages.