### PR TITLE
fix: set relationtype if accountRelation is type `string`

### DIFF
--- a/packages/devtools/CHANGELOG.md
+++ b/packages/devtools/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @composedb/devtools
 
+## UNRELEASED
+
+### Patch Changes
+
+- Fix relation type during creation of `RuntimeCompositeDefinition`
+
 ## 0.3.1
 
 ### Patch Changes

--- a/packages/devtools/src/formats/runtime.ts
+++ b/packages/devtools/src/formats/runtime.ts
@@ -280,7 +280,14 @@ export function createRuntimeDefinition(
     // Attach entry-point to account store based on relation type
     if (modelDefinition.accountRelation != null) {
       const key = camelCase(modelName)
-      const relationType = modelDefinition.accountRelation.type
+      let relationType = modelDefinition.accountRelation.type
+
+      if (
+        typeof modelDefinition.accountRelation === 'string' &&
+        (modelDefinition.accountRelation === 'single' || modelDefinition.accountRelation === 'list')) {
+        relationType = modelDefinition.accountRelation
+      }
+
       if (relationType === 'single') {
         runtime.accountData[key] = { type: 'node', name: modelName }
         // @ts-ignore TS2367, should be unnecessary check based on type definition but more types
@@ -288,7 +295,7 @@ export function createRuntimeDefinition(
       } else if (relationType === 'list') {
         runtime.accountData[key + 'List'] = { type: 'connection', name: modelName }
       } else {
-        throw new Error(`Unsupported account relation type: ${relationType as string}`)
+        throw new Error(`Unsupported account relation type: ${relationType}`)
       }
     }
   }


### PR DESCRIPTION
# Allow account relations to always be set

## Description

Hey! Hopefully this PR is welcome!

I have been playing around locally with ComposeDB (as seen [here](https://twitter.com/WhiteR4bbitt/status/1621050573251571713?s=20&t=ukJgeMeMN8Feo44qaCiuMA)).

I was trying to index random **Stream IDs** and encountered this on a lot of random IDs.
```bash
Error: Unsupported account relation type: undefined
```  

After some discovery it appears that some (maybe OLD?) model objects `accountRelation` field is actually a type `string` that is set to `single` or `list`.

2 Logs during discovery:
```bash
createRuntimeDefinition:  {
  aliases: {},
  commonEmbeds: [],
  version: '1.0',
  models: {
    kjzl6hvfrbw6c7keo17n66rxyo21nqqaa9lh491jz16od43nokz7ksfcvzi6bwc: {
      name: 'SimpleProfile',
      views: [Object],
      schema: [Object],
      relations: {},
      description: 'Simple example profile',
      accountRelation: [Object]
    }
  },
  views: { account: {}, root: {}, models: {} }
}
```
```bash
createRuntimeDefinition:  {
  aliases: {},
  commonEmbeds: [],
  version: '1.0',
  models: {
    kjzl6hvfrbw6ca7nidsnrv78x7r4xt0xki71nvwe4j5a3s9wgou8yu3aj8cz38e: {
      name: 'SimpleProfile',
      views: [Object],
      schema: [Object],
      description: 'Simple example profile',
      accountRelation: 'single'
    }
  },
  views: { account: {}, root: {}, models: {} }
}
```

## How Has This Been Tested?

Describe the tests that you ran to verify your changes. Provide instructions for reproduction.

- [ ] Loaded local Model loader
- [ ] Used Stream IDs passing & failing
- [ ] Created composite & definintion
- [ ] Successfully synced to local ceramic testnet node

## Definition of Done

Before submitting this PR, please make sure:

- [ ] The work addresses the description and outcomes in the issue
- [ ] I have added relevant tests for new or updated functionality
- [ ] My code follows conventions, is well commented, and easy to understand
- [ ] My code builds and tests pass without any errors or warnings
- [ ] I have tagged the relevant reviewers
- [ ] I have updated the READMEs of affected packages
- [ ] I have made corresponding changes to the documentation
- [ ] The changes have been communicated to interested parties

## References:
Previously failed to create local composite/definition, could not sync either, now:
ID: `kjzl6hvfrbw6canyzu5r28z6133gbl4dkewbkjioglf8zd9krh5au2ea43bqnwv`
![image](https://user-images.githubusercontent.com/5930847/217399102-6751d26f-6094-4005-b6de-e83aad3c2db3.png)

![image](https://user-images.githubusercontent.com/5930847/217399168-ba108549-aeae-4b01-ab3a-9a17fe465947.png)

