### PR TITLE
Use Model.VERSION on the client

### DIFF
--- a/packages/devtools/src/schema/compiler.ts
+++ b/packages/devtools/src/schema/compiler.ts
@@ -19,7 +19,7 @@ import type {
   ScalarFieldDefinition,
   SchemaDefinition,
 } from './types.js'
-import { Composite } from "../composite.js"
+import { Model } from '@ceramicnetwork/stream-model'
 
 type CompileObject = SetRequired<JSONSchema.Object, 'properties'>
 
@@ -324,8 +324,7 @@ export class SchemaCompiler {
     return {
       action: 'create',
       model: {
-        // TODO: CDB-2264 Use something else other than Composite.VERSION
-        version: Composite.VERSION,
+        version: Model.VERSION,
         name,
         description: modelDefinition.description,
         // TODO: add once supported in model definition


### PR DESCRIPTION
Use Model.VERSION on the client to set the version field in models created by composites

