### PR TITLE
did-session is an unscoped package, do not use @

### DIFF
--- a/website/docs/guides/composedb-client/user-sessions.mdx
+++ b/website/docs/guides/composedb-client/user-sessions.mdx
@@ -26,21 +26,21 @@ First, install the did-sessions library:
   <TabItem value="npm">
 
 ```bash
-npm install @did-session
+npm install did-session
 ```
 
   </TabItem>
   <TabItem value="pnpm">
 
 ```bash
-pnpm add @did-session
+pnpm add did-session
 ```
 
   </TabItem>
   <TabItem value="yarn">
 
 ```bash
-yarn add @did-session
+yarn add did-session
 ```
 
   </TabItem>


### PR DESCRIPTION
# Correct User Session instructions - #ADOPT-1058

## Description

The docs contain an erroneous '@' leading to this error
```
% pnpm add @did-session
@ceramicnetwork/metrics is linked to /Users/gv/node_modules from /Users/gv/js-ceramic/packages/metrics
 ERR_PNPM_SPEC_NOT_SUPPORTED_BY_ANY_RESOLVER  @did-session isn't supported by any available resolver.
gv@birdbox LinkedTrust %
```

## How Has This Been Tested?

Describe the tests that you ran to verify your changes. Provide instructions for reproduction.

- [x ] Verified manually

