### PR TITLE
include instructions for compiling to javascript

### DIFF
--- a/website/docs/guides/data-modeling/composites.mdx
+++ b/website/docs/guides/data-modeling/composites.mdx
@@ -143,6 +143,12 @@ After deploying your composite, compile it so you can start perform [Data Intera
 composedb composite:compile my-first-composite.json runtime-composite.json
 ```
 
+To compile your composite for import and use with the [JavasScript Client](../../guides/composedb-client/javascript-client.mdx), just specify an output file ending in .js 
+
+```bash
+composedb composite:compile my-first-composite.json runtime-composite.js
+```
+
 ## Advanced
 ### Merging composites
 


### PR DESCRIPTION
# docs expect user to have compiled to javascript - #PORT-86

## Description

The Javascript Client doc page refers to a compiled composite ending with .js, but the preceding pages did not describe how to produce this file.  Add a line to the docs telling developers how to compile to a javascript file

## How Has This Been Tested?

- [x ] Tested manually
