### PR TITLE
Include instructions to list models on clay

### DIFF
--- a/website/docs/create-your-composite.mdx
+++ b/website/docs/create-your-composite.mdx
@@ -22,7 +22,11 @@ To list all models in the model catalog, run the following command:
 composedb model:list --table
 ```
 
-Here, the flag `--table` will display the output in an organized table view and provide more details about each model’s functionality.
+Here, the flag `--table` will display the output in an organized table view and provide more details about each model’s functionality.  By default, this command lists models in production on mainnet.  To see models being developed on clay testnet, specify a clay ceramic node as the list source:
+
+```bash
+composedb model:list -i https://ceramic-private-clay.3boxlabs.com/
+```
 
 **Response:** Below see a small snippet of the the output table. Each model has the following properties:
 

--- a/website/docs/create-your-composite.mdx
+++ b/website/docs/create-your-composite.mdx
@@ -25,7 +25,7 @@ composedb model:list --table
 Here, the flag `--table` will display the output in an organized table view and provide more details about each model’s functionality.  By default, this command lists models in production on mainnet.  To see models being developed on clay testnet, specify a clay ceramic node as the list source:
 
 ```bash
-composedb model:list -i https://ceramic-private-clay.3boxlabs.com/
+composedb model:list -i https://ceramic-private-clay.3boxlabs.com/ --table
 ```
 
 **Response:** Below see a small snippet of the the output table. Each model has the following properties:


### PR DESCRIPTION
# Ensure hackathon devs can find models 

## Description

By default we list models on mainnet, but there are not any models currently on mainnet

Tell new developers how to find models on clay as well

Tested manually.
