### PR TITLE
Update example to use new --network flag to get models from clay

### DIFF
--- a/website/docs/create-your-composite.mdx
+++ b/website/docs/create-your-composite.mdx
@@ -22,10 +22,10 @@ To list all models in the model catalog, run the following command:
 composedb model:list --table
 ```
 
-Here, the flag `--table` will display the output in an organized table view and provide more details about each model’s functionality.  By default, this command lists models in production on mainnet.  To see models being developed on clay testnet, specify a ceramic node running on the clay testnet that is configured to index the set of all models.  Once such node is available at `https://ceramic-private-clay.3boxlabs.com/`, so an example of how to see the models deployed on clay is:
+Here, the flag `--table` will display the output in an organized table view and provide more details about each model’s functionality.  By default, this command lists models in production on mainnet.  To see models being developed on clay testnet, specify `--network=testnet-clay`:
 
 ```bash
-composedb model:list -i https://ceramic-private-clay.3boxlabs.com/ --table
+composedb model:list --network=testnet-clay --table
 ```
 
 **Response:** Below see a small snippet of the the output table. Each model has the following properties:


### PR DESCRIPTION
Depends on https://github.com/ceramicstudio/js-composedb/pull/97 being merged