### PR TITLE
correct the npm install - this shows up at npm site

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -6,7 +6,7 @@
 ## Installation
 
 ```sh
-npm install -g @composedbd/cli
+npm install -g @composedb/cli
 ```
 
 ## Usage


### PR DESCRIPTION
# typo in npm package instructions - #CDB-2488

## Description

Fixes the instructions so people can copy and paste to install @composedb/cli

## How Has This Been Tested?



- [ x] Tested that the correct instructions work


## Definition of Done

Before submitting this PR, please make sure:

This PR needs to be merged and then published, in order to fix the docs at npmjs.com

- [ ] The work addresses the description and outcomes in the issue
- [ ] I have added relevant tests for new or updated functionality
- [ ] My code follows conventions, is well commented, and easy to understand
- [ ] My code builds and tests pass without any errors or warnings
- [ ] I have tagged the relevant reviewers
- [ ] I have updated the READMEs of affected packages
- [ ] I have made corresponding changes to the documentation
- [ ] The changes have been communicated to interested parties

## References:

Please list relevant documentation (e.g. tech specs, articles, related work etc.) relevant to this change, and note if the documentation has been updated.
