### PR TITLE
add roadmap

### DIFF
--- a/website/docs/api/modules/devtools.md
+++ b/website/docs/api/modules/devtools.md
@@ -40,13 +40,14 @@ ___
 | Name | Type |
 | :------ | :------ |
 | `action` | ``"create"`` |
+| `indices?` | `FieldsIndex`[] |
 | `model` | `ModelDefinition` |
 
 ___
 
 ### AbstractLoadModelDefinition
 
-Ƭ **AbstractLoadModelDefinition**: [`ParsedLoadModelDefinition`](devtools.md#parsedloadmodeldefinition) & { `views`: `ModelViewsDefinition`  }
+Ƭ **AbstractLoadModelDefinition**: [`ParsedLoadModelDefinition`](devtools.md#parsedloadmodeldefinition) & { `indices?`: `FieldsIndex`[] ; `views`: `ModelViewsDefinition`  }
 
 ___
 
@@ -179,6 +180,7 @@ ___
 
 | Name | Type |
 | :------ | :------ |
+| `indices` | `FieldsIndex`[] |
 | `properties` | [`ObjectFieldsDefinition`](devtools.md#objectfieldsdefinition) |
 | `references` | `string`[] |
 | `relations` | `ModelRelationsDefinition` |

--- a/website/versioned_docs/version-0.4.x/ceramic-roadmap.mdx
+++ b/website/versioned_docs/version-0.4.x/ceramic-roadmap.mdx
@@ -1,0 +1,22 @@
+# ComposeDB roadmap
+
+Since the launch of the ComposeDB Beta, the core Ceramic team remains committed to making ongoing improvements
+to both ComposeDB and the underlying Ceramic protocol. Concurrently, we seek to involve the Ceramic developer
+community in shaping Ceramic's future. We value your active participation in helping us prioritize the features 
+and improvements that matter most to our developer base.
+
+**All curent and future projects are outlined in the [Ceramic roadmap](https://github.com/orgs/ceramicstudio/projects/2).**
+
+We welcome your feedback and insights on our roadmap priorities. You can show your support or express your concerns
+about projects on the roadmap by upvoting or downvoting them. Additionally, we encourage you to leave more detailed 
+comments, making suggestions or indicating relevant feature requests.
+
+
+
+
+
+
+
+
+
+

--- a/website/versioned_sidebars/version-0.4.x-sidebars.json
+++ b/website/versioned_sidebars/version-0.4.x-sidebars.json
@@ -55,6 +55,11 @@
     },
     {
       "type": "doc",
+      "id": "ceramic-roadmap",
+      "label": "Roadmap"
+    },
+    {
+      "type": "doc",
       "id": "community",
       "label": "Community"
     }


### PR DESCRIPTION
# Add Ceramic roadmap to ComposeDB docs 

## Description

Since we are planning to share public product roadmap with the community, we want to reference it on the docs so that it's easier to find it.


