### PR TITLE
fix: CDB-2630 No Filters in Graphiql

### DIFF
--- a/packages/cli/test/composites.test.ts
+++ b/packages/cli/test/composites.test.ts
@@ -62,6 +62,7 @@ describe('composites', () => {
       ])
       const output = create.stdout.toString()
       expect(output.includes('"version":"1.0"')).toBe(true)
+      expect(output.includes('"indices":{"Post"')).toBe(true)
       expect(output.includes('"aliases":')).toBe(true)
       expect(output.includes('"views":')).toBe(true)
     }, 60000)

--- a/packages/cli/test/scripts/data/composite.picture.post.schema
+++ b/packages/cli/test/scripts/data/composite.picture.post.schema
@@ -1,4 +1,7 @@
-type Picture @createModel(accountRelation: LIST, description: "A Picture model") {
+type Picture
+  @createModel(accountRelation: LIST, description: "A Picture model")
+  @createIndex(fields: [{path: ["url"]}])
+{
   url: String! @string(minLength: 0, maxLength: 140)
 }
 

--- a/packages/devtools/src/composite.ts
+++ b/packages/devtools/src/composite.ts
@@ -662,6 +662,7 @@ export class Composite {
     return {
       version: this.#definition.version,
       models: encodeSignedMap(this.#commits),
+      indices: this.#definition.indices,
       aliases: this.#definition.aliases,
       views: this.#definition.views,
     }

--- a/packages/devtools/test/__snapshots__/composite.test.ts.snap
+++ b/packages/devtools/test/__snapshots__/composite.test.ts.snap
@@ -3,6 +3,7 @@
 exports[`composite Composite instance toJSON() returns a JSON-encoded composite 1`] = `
 {
   "aliases": {},
+  "indices": {},
   "models": {},
   "version": "1.0",
   "views": {


### PR DESCRIPTION
Compiled runtime composites now include indices so that filters can be generated.