### PR TITLE
fix composite.merge for indices

### DIFF
--- a/packages/devtools/src/composite.ts
+++ b/packages/devtools/src/composite.ts
@@ -580,6 +580,7 @@ export class Composite {
       Object.assign(nextParams.commits, commits)
       Object.assign(nextDefinition.models, definition.models)
       Object.assign(nextDefinition.aliases, def.aliases)
+      Object.assign(nextDefinition.indices, def.indices)
       merge(nextDefinition.views, def.views)
       for (const name of def.commonEmbeds) {
         collectedEmbeds.add(name)

--- a/packages/devtools/test/composite.test.ts
+++ b/packages/devtools/test/composite.test.ts
@@ -10,6 +10,8 @@ import {
   loadPostSchemaWithComments,
   postSchema,
   profilesSchema,
+  noteSchema,
+  ratingSchema,
 } from '@composedb/test-schemas'
 import type { ModelDefinition } from '@composedb/types'
 import { jest } from '@jest/globals'
@@ -550,6 +552,16 @@ describe('composite', () => {
           models: {},
           root: { foo: 'test' },
         })
+      })
+
+      test('with indices', async () => {
+        const postComposite = await Composite.create({ ceramic, schema: postSchema })
+        const ratingComposite = await Composite.create({ ceramic, schema: ratingSchema })
+        const noteComposite = await Composite.create({ ceramic, schema: noteSchema })
+        const mergedComposite = postComposite.merge([ratingComposite, noteComposite]).toJSON()
+        expect(mergedComposite).toHaveProperty('indices.Post')
+        expect(mergedComposite).toHaveProperty('indices.Rating')
+        expect(mergedComposite).toHaveProperty('indices.Note')
       })
     })
   })


### PR DESCRIPTION
## Description

The merge method from Composite class discards all the additional indices from the merged sources.
This patch fixes it by ensuring that the indices are being passed to the nextDefinition

## How Has This Been Tested?

I've used this package versions with my local inmemory configuration
```
    "@ceramicnetwork/cli": "2.36.0-rc.2",
    "@ceramicnetwork/common": "2.31.0-rc.1",
    "@ceramicnetwork/http-client": "2.28.0-rc.1",
    "@composedb/cli": "0.5.0-rc.2",
    "@composedb/client": "0.5.0-rc.2",
    "@composedb/devtools": "0.5.0-rc.2",
    "@composedb/devtools-node": "0.5.0-rc.2"
```

## Definition of Done

Before submitting this PR, please make sure:

- [x] The work addresses the description and outcomes in the issue
- [x] I have added relevant tests for new or updated functionality
- [x] My code follows conventions, is well commented, and easy to understand
- [x] My code builds and tests pass without any errors or warnings
- [x] I have tagged the relevant reviewers
- [ ] I have updated the READMEs of affected packages
- [ ] I have made corresponding changes to the documentation
- [x] The changes have been communicated to interested parties

