### PR TITLE
Add product roadmap to 5.x and livedocs

### DIFF
--- a/website/docs/ceramic-roadmap.mdx
+++ b/website/docs/ceramic-roadmap.mdx
@@ -1,0 +1,12 @@
+# ComposeDB roadmap
+
+Since the launch of the ComposeDB Beta, the core Ceramic team remains committed to making ongoing improvements
+to both ComposeDB and the underlying Ceramic protocol. Concurrently, we seek to involve the Ceramic developer
+community in shaping Ceramic's future. We value your active participation in helping us prioritize the features 
+and improvements that matter most to our developer base.
+
+**All curent and future projects are outlined in the [Ceramic roadmap](https://github.com/orgs/ceramicstudio/projects/2).**
+
+We welcome your feedback and insights on our roadmap priorities. You can show your support or express your concerns
+about projects on the roadmap by upvoting or downvoting them. Additionally, we encourage you to leave more detailed 
+comments, making suggestions or indicating relevant feature requests.

--- a/website/sidebars.js
+++ b/website/sidebars.js
@@ -32,6 +32,7 @@ const sidebars = {
       ],
     },
     { type: 'doc', id: 'core-concepts', label: 'Core Concepts' },
+    { type: 'doc', id: 'ceramic-roadmap', label: 'Roadmap' },
     { type: 'doc', id: 'community', label: 'Community' },
   ],
   guides: [

--- a/website/versioned_docs/version-0.5.x/ceramic-roadmap.mdx
+++ b/website/versioned_docs/version-0.5.x/ceramic-roadmap.mdx
@@ -1,0 +1,12 @@
+# ComposeDB roadmap
+
+Since the launch of the ComposeDB Beta, the core Ceramic team remains committed to making ongoing improvements
+to both ComposeDB and the underlying Ceramic protocol. Concurrently, we seek to involve the Ceramic developer
+community in shaping Ceramic's future. We value your active participation in helping us prioritize the features 
+and improvements that matter most to our developer base.
+
+**All curent and future projects are outlined in the [Ceramic roadmap](https://github.com/orgs/ceramicstudio/projects/2).**
+
+We welcome your feedback and insights on our roadmap priorities. You can show your support or express your concerns
+about projects on the roadmap by upvoting or downvoting them. Additionally, we encourage you to leave more detailed 
+comments, making suggestions or indicating relevant feature requests.

--- a/website/versioned_sidebars/version-0.5.x-sidebars.json
+++ b/website/versioned_sidebars/version-0.5.x-sidebars.json
@@ -54,6 +54,11 @@
     },
     {
       "type": "doc",
+      "id": "ceramic-roadmap",
+      "label": "Roadmap"
+    },
+    {
+      "type": "doc",
       "id": "community",
       "label": "Community"
     }


### PR DESCRIPTION
Add the product roadmap to 5.x docs as well as livedocs so that we keep it in for future releases as well.