### PR TITLE
Add `nodes` entry point to GraphQL queries

### DIFF
--- a/packages/cli/test/__snapshots__/graphql.test.ts.snap
+++ b/packages/cli/test/__snapshots__/graphql.test.ts.snap
@@ -2,6 +2,12 @@
 
 exports[`graphql graphql:schema printing graphql schema succeeds 1`] = `
 "type Query {
+  """Fetches objects given their IDs"""
+  nodes(
+    """The IDs of objects"""
+    ids: [ID!]!
+  ): [Node]!
+
   """Fetches an object given its ID"""
   node(
     """The ID of an object"""
@@ -256,6 +262,12 @@ input PartialPictureInput {
 
 exports[`graphql graphql:schema printing graphql schema succeeds with --readonly flag 1`] = `
 "type Query {
+  """Fetches objects given their IDs"""
+  nodes(
+    """The IDs of objects"""
+    ids: [ID!]!
+  ): [Node]!
+
   """Fetches an object given its ID"""
   node(
     """The ID of an object"""

--- a/packages/runtime/src/schema.ts
+++ b/packages/runtime/src/schema.ts
@@ -849,7 +849,10 @@ class SchemaBuilder {
   }
 
   _createSchema(definitions: SharedDefinitions) {
-    const queryFields = { ...definitions.queryFields }
+    const queryFields: GraphQLFieldConfigMap<unknown, Context> = {
+      nodes: definitions.nodesField,
+      ...definitions.queryFields,
+    }
 
     for (const [alias, model] of Object.entries(this.#def.models)) {
       const first = alias[0].toLowerCase()

--- a/packages/runtime/test/__snapshots__/runtime.test.ts.snap
+++ b/packages/runtime/test/__snapshots__/runtime.test.ts.snap
@@ -35,6 +35,12 @@ exports[`runtime create a document with enum 1`] = `
 
 exports[`runtime create and query post with comments 1`] = `
 "type Query {
+  """Fetches objects given their IDs"""
+  nodes(
+    """The IDs of objects"""
+    ids: [ID!]!
+  ): [Node]!
+
   """Fetches an object given its ID"""
   node(
     """The ID of an object"""
@@ -340,6 +346,17 @@ input PartialPostInput {
 exports[`runtime create and query post with comments 2`] = `
 {
   "data": {
+    "comments": [
+      {
+        "text": "A first comment",
+      },
+      {
+        "text": "A second comment",
+      },
+      {
+        "text": "A third comment",
+      },
+    ],
     "viewer": {
       "postList": {
         "edges": [

--- a/packages/runtime/test/__snapshots__/schema.test.ts.snap
+++ b/packages/runtime/test/__snapshots__/schema.test.ts.snap
@@ -2,6 +2,12 @@
 
 exports[`schema extra scalars 1`] = `
 "type Query {
+  """Fetches objects given their IDs"""
+  nodes(
+    """The IDs of objects"""
+    ids: [ID!]!
+  ): [Node]!
+
   """Fetches an object given its ID"""
   node(
     """The ID of an object"""
@@ -311,6 +317,12 @@ input UpdateOptionsInput {
 
 exports[`schema note 1`] = `
 "type Query {
+  """Fetches objects given their IDs"""
+  nodes(
+    """The IDs of objects"""
+    ids: [ID!]!
+  ): [Node]!
+
   """Fetches an object given its ID"""
   node(
     """The ID of an object"""
@@ -522,6 +534,12 @@ input UpdateOptionsInput {
 
 exports[`schema post and comments 1`] = `
 "type Query {
+  """Fetches objects given their IDs"""
+  nodes(
+    """The IDs of objects"""
+    ids: [ID!]!
+  ): [Node]!
+
   """Fetches an object given its ID"""
   node(
     """The ID of an object"""
@@ -826,6 +844,12 @@ input PartialPostInput {
 
 exports[`schema profile 1`] = `
 "type Query {
+  """Fetches objects given their IDs"""
+  nodes(
+    """The IDs of objects"""
+    ids: [ID!]!
+  ): [Node]!
+
   """Fetches an object given its ID"""
   node(
     """The ID of an object"""


### PR DESCRIPTION
Support for this entry point is provided by the GraphQL library so adding support for it is trivial, this PR simply enables it.