### PR TITLE
Add noindex tags to older versions of the docs

### DIFF
--- a/website/versioned_docs/version-0.2.x/api/classes/client.ComposeClient.md
+++ b/website/versioned_docs/version-0.2.x/api/classes/client.ComposeClient.md
@@ -4,6 +4,11 @@ title: "Class: ComposeClient"
 custom_edit_url: null
 ---
 
+<head>
+  <meta name="robots" content="noindex" />
+  <meta name="googlebot" content="noindex" />
+</head>
+
 [client](../modules/client.md).ComposeClient
 
 The ComposeClient class provides APIs to execute queries on a GraphQL schema generated from a

--- a/website/versioned_docs/version-0.2.x/api/classes/client.Context.md
+++ b/website/versioned_docs/version-0.2.x/api/classes/client.Context.md
@@ -4,6 +4,11 @@ title: "Class: Context"
 custom_edit_url: null
 ---
 
+<head>
+  <meta name="robots" content="noindex" />
+  <meta name="googlebot" content="noindex" />
+</head>
+
 [client](../modules/client.md).Context
 
 GraphQL execution context, exported by the [`client`](../modules/client.md) module.

--- a/website/versioned_docs/version-0.2.x/api/classes/devtools.Composite.md
+++ b/website/versioned_docs/version-0.2.x/api/classes/devtools.Composite.md
@@ -4,6 +4,11 @@ title: "Class: Composite"
 custom_edit_url: null
 ---
 
+<head>
+  <meta name="robots" content="noindex" />
+  <meta name="googlebot" content="noindex" />
+</head>
+
 [devtools](../modules/devtools.md).Composite
 
 The Composite class provides APIs for managing composites (sets of Model streams) through their

--- a/website/versioned_docs/version-0.2.x/api/commands/cli.composite.md
+++ b/website/versioned_docs/version-0.2.x/api/commands/cli.composite.md
@@ -4,6 +4,11 @@ title: "CLI: composite:* commands"
 custom_edit_url: null
 ---
 
+<head>
+  <meta name="robots" content="noindex" />
+  <meta name="googlebot" content="noindex" />
+</head>
+
 The group of [CLI](../modules/cli.md) `composite:*` commands enables the creation and interactions with [Composites](../../guides/concepts-overview.md#composites)
 
 ## Command List

--- a/website/versioned_docs/version-0.2.x/api/commands/cli.did.md
+++ b/website/versioned_docs/version-0.2.x/api/commands/cli.did.md
@@ -4,6 +4,11 @@ title: "CLI: did:* commands"
 custom_edit_url: null
 ---
 
+<head>
+  <meta name="robots" content="noindex" />
+  <meta name="googlebot" content="noindex" />
+</head>
+
 The group of [CLI](../modules/cli.md) `did:*` commands enables interactions with
 DIDs and private keys
 

--- a/website/versioned_docs/version-0.2.x/api/commands/cli.document.md
+++ b/website/versioned_docs/version-0.2.x/api/commands/cli.document.md
@@ -4,6 +4,11 @@ title: "CLI: document:* commands"
 custom_edit_url: null
 ---
 
+<head>
+  <meta name="robots" content="noindex" />
+  <meta name="googlebot" content="noindex" />
+</head>
+
 The group of [CLI](../modules/cli.md) `document:*` commands enables the creation and interactions with [Documents](../../guides/concepts-overview.md#documents)
 
 ## Command List

--- a/website/versioned_docs/version-0.2.x/api/commands/cli.graphql.md
+++ b/website/versioned_docs/version-0.2.x/api/commands/cli.graphql.md
@@ -4,6 +4,11 @@ title: "CLI: graphql:* commands"
 custom_edit_url: null
 ---
 
+<head>
+  <meta name="robots" content="noindex" />
+  <meta name="googlebot" content="noindex" />
+</head>
+
 The group of [CLI](../modules/cli.md) `graphql:*` commands makes it possible to generate GraphQL Schemas from [runtime definitions](./cli.composite.md#composedb-compositecompile) of your [Composites](../../guides/concepts-overview.md#composites) and run a local GraphQL HTTP server
 
 ## Command List

--- a/website/versioned_docs/version-0.2.x/api/commands/cli.model.md
+++ b/website/versioned_docs/version-0.2.x/api/commands/cli.model.md
@@ -4,6 +4,11 @@ title: "CLI: model:* commands"
 custom_edit_url: null
 ---
 
+<head>
+  <meta name="robots" content="noindex" />
+  <meta name="googlebot" content="noindex" />
+</head>
+
 The group of [CLI](../modules/cli.md) `model:*` commands enables discovery of [Models](../../guides/concepts-overview.md#models), as well as their creation and interactions with them
 
 ## Command List

--- a/website/versioned_docs/version-0.2.x/api/index.md
+++ b/website/versioned_docs/version-0.2.x/api/index.md
@@ -5,6 +5,13 @@ hide_table_of_contents: true
 custom_edit_url: null
 ---
 
+<head>
+  <meta name="robots" content="noindex" />
+  <meta name="googlebot" content="noindex" />
+</head>
+
+
+
 ## Modules
 
 - [client](modules/client.md)

--- a/website/versioned_docs/version-0.2.x/api/modules/cli.md
+++ b/website/versioned_docs/version-0.2.x/api/modules/cli.md
@@ -4,6 +4,11 @@ title: "Module: CLI"
 custom_edit_url: null
 ---
 
+<head>
+  <meta name="robots" content="noindex" />
+  <meta name="googlebot" content="noindex" />
+</head>
+
 ComposeDB CLI - the Command Line Interface that enables interactions with a Ceramic Node
 
 You can check the [Getting Started](../../first-composite.mdx) Section for some examples (remember to switch to the 'Using the CLI' tab!)

--- a/website/versioned_docs/version-0.2.x/api/modules/client.md
+++ b/website/versioned_docs/version-0.2.x/api/modules/client.md
@@ -4,6 +4,11 @@ title: "Module: client"
 custom_edit_url: null
 ---
 
+<head>
+  <meta name="robots" content="noindex" />
+  <meta name="googlebot" content="noindex" />
+</head>
+
 ComposeDB client.
 
 ## Installation

--- a/website/versioned_docs/version-0.2.x/api/modules/devtools.md
+++ b/website/versioned_docs/version-0.2.x/api/modules/devtools.md
@@ -4,6 +4,11 @@ title: "Module: devtools"
 custom_edit_url: null
 ---
 
+<head>
+  <meta name="robots" content="noindex" />
+  <meta name="googlebot" content="noindex" />
+</head>
+
 Development tools library.
 
 ## Installation

--- a/website/versioned_docs/version-0.2.x/api/modules/devtools_node.md
+++ b/website/versioned_docs/version-0.2.x/api/modules/devtools_node.md
@@ -4,6 +4,11 @@ title: "Module: devtools-node"
 custom_edit_url: null
 ---
 
+<head>
+  <meta name="robots" content="noindex" />
+  <meta name="googlebot" content="noindex" />
+</head>
+
 Node.js-specific development tools.
 
 ## Installation

--- a/website/versioned_docs/version-0.2.x/client-setup.mdx
+++ b/website/versioned_docs/version-0.2.x/client-setup.mdx
@@ -3,6 +3,11 @@ import TabItem from '@theme/TabItem'
 
 # Client setup
 
+<head>
+  <meta name="robots" content="noindex" />
+  <meta name="googlebot" content="noindex" />
+</head>
+
 ## Compiling the composite
 
 In order to interact with a composite at runtime, it is first necessary to create a runtime composite definition file that will be used to configure the client.

--- a/website/versioned_docs/version-0.2.x/first-composite.mdx
+++ b/website/versioned_docs/version-0.2.x/first-composite.mdx
@@ -3,6 +3,11 @@ import TabItem from '@theme/TabItem'
 
 # Your first composite
 
+<head>
+  <meta name="robots" content="noindex" />
+  <meta name="googlebot" content="noindex" />
+</head>
+
 ComposeDB provides an abstraction on top of Ceramic streams by leveraging composites, an internal data structure referencing Ceramic model streams and associated metadata. Most of ComposeDB tools and clients interact with various representations of composites.
 
 This page presents how to create your first composite and deploy it to your local Ceramic node, in order to interact with documents on Ceramic.

--- a/website/versioned_docs/version-0.2.x/guides/concepts-overview.md
+++ b/website/versioned_docs/version-0.2.x/guides/concepts-overview.md
@@ -1,5 +1,10 @@
 # Concepts overview
 
+<head>
+  <meta name="robots" content="noindex" />
+  <meta name="googlebot" content="noindex" />
+</head>
+
 ComposeDB provides a **graph structure** for interacting with data on the [Ceramic network](https://ceramic.network/).
 
 The **nodes** in the graph can be **accounts** or **documents**, while the **edges** in the graph represent relations between **nodes**.

--- a/website/versioned_docs/version-0.2.x/guides/creating-composites/directives.md
+++ b/website/versioned_docs/version-0.2.x/guides/creating-composites/directives.md
@@ -1,5 +1,10 @@
 # Supported directives
 
+<head>
+  <meta name="robots" content="noindex" />
+  <meta name="googlebot" content="noindex" />
+</head>
+
 Directives provide extra metadata when declaring scalars, lists and shapes.
 
 ## Model identification

--- a/website/versioned_docs/version-0.2.x/guides/creating-composites/overview.mdx
+++ b/website/versioned_docs/version-0.2.x/guides/creating-composites/overview.mdx
@@ -3,6 +3,11 @@ import TabItem from '@theme/TabItem'
 
 # Creating Composites
 
+<head>
+  <meta name="robots" content="noindex" />
+  <meta name="googlebot" content="noindex" />
+</head>
+
 Composites are the abstraction ComposeDB tools and client use to represent and manipulate data models used by applications.
 
 In order to create new composites, especially to create new models that do not already exist on the Ceramic network, a high-level schema can be used as an abstraction for the composite structure.

--- a/website/versioned_docs/version-0.2.x/guides/creating-composites/scalars.md
+++ b/website/versioned_docs/version-0.2.x/guides/creating-composites/scalars.md
@@ -1,5 +1,10 @@
 # Supported scalars
 
+<head>
+  <meta name="robots" content="noindex" />
+  <meta name="googlebot" content="noindex" />
+</head>
+
 Scalars represent the leaf values in the graph, either as part of key-value properties in shapes, or value of items in lists. You can learn more about scalars in the [GraphQL specification](https://graphql.org/learn/schema/#scalar-types).
 
 ## Primitive types

--- a/website/versioned_docs/version-0.2.x/guides/creating-composites/schema.md
+++ b/website/versioned_docs/version-0.2.x/guides/creating-composites/schema.md
@@ -1,5 +1,10 @@
 # Schema definition
 
+<head>
+  <meta name="robots" content="noindex" />
+  <meta name="googlebot" content="noindex" />
+</head>
+
 Composite schemas are based on [GraphQL's Schema Definition Language](https://graphql.org/learn/schema/), using a subset of functionalities offered by GraphQL to describe models used by ComposeDB.
 
 ## Schema Definition Language

--- a/website/versioned_docs/version-0.2.x/guides/data-composition.mdx
+++ b/website/versioned_docs/version-0.2.x/guides/data-composition.mdx
@@ -3,6 +3,11 @@ import ThemedImage from '@theme/ThemedImage'
 
 # Data composition
 
+<head>
+  <meta name="robots" content="noindex" />
+  <meta name="googlebot" content="noindex" />
+</head>
+
 Data composition is at the heart of ComposeDB, using [composites](./concepts-overview.md#composites) as a proxy for datasets of [documents](./concepts-overview.md#documents) relevant to applications and services.
 
 Composites represent sets of [models](./concepts-overview.md#models) that can be used to query, create and update documents, therefore it is important for developers to identify models to use, whether by [reusing models already adopted by the ecosystem](./using-composites/discovery.mdx) in order to access the set of documents already created using these models, or [creating new models](./creating-composites/overview.mdx) that would better suit specific needs.

--- a/website/versioned_docs/version-0.2.x/guides/index.mdx
+++ b/website/versioned_docs/version-0.2.x/guides/index.mdx
@@ -3,4 +3,9 @@ import { useCurrentSidebarCategory } from '@docusaurus/theme-common'
 
 # Guides
 
+<head>
+  <meta name="robots" content="noindex" />
+  <meta name="googlebot" content="noindex" />
+</head>
+
 <DocCardList items={useCurrentSidebarCategory().items} />

--- a/website/versioned_docs/version-0.2.x/guides/interacting/mutations.mdx
+++ b/website/versioned_docs/version-0.2.x/guides/interacting/mutations.mdx
@@ -1,5 +1,10 @@
 # Performing mutations
 
+<head>
+  <meta name="robots" content="noindex" />
+  <meta name="googlebot" content="noindex" />
+</head>
+
 ## Enabling mutations
 
 In order to perform mutations, the Ceramic instance used by the ComposeDB client needs to be authenticated. This can be done by calling the [`setDID` method](../../api/classes/client.ComposeClient.md#setdid) on the [`ComposeClient`](../../api/classes/client.ComposeClient.md) instance with an authenticated `DID` instance:

--- a/website/versioned_docs/version-0.2.x/guides/interacting/queries.md
+++ b/website/versioned_docs/version-0.2.x/guides/interacting/queries.md
@@ -1,5 +1,10 @@
 # Querying the graph
 
+<head>
+  <meta name="robots" content="noindex" />
+  <meta name="googlebot" content="noindex" />
+</head>
+
 The [`ComposeClient`](../../api/classes/client.ComposeClient.md) automatically generates a GraphQL Schema from the runtime composite definition.
 
 It notablly creates a [`CeramicAccount` object](#ceramicaccount-object) that replaces [`DID` scalar](../creating-composites/scalars.md#did) representations, and the root [`Query` object](#query-object) used as an entry-point to acces the graph.

--- a/website/versioned_docs/version-0.2.x/guides/interacting/using-apollo.md
+++ b/website/versioned_docs/version-0.2.x/guides/interacting/using-apollo.md
@@ -1,5 +1,10 @@
 # Using Apollo
 
+<head>
+  <meta name="robots" content="noindex" />
+  <meta name="googlebot" content="noindex" />
+</head>
+
 :::tip What is Apollo?
 
 [Apollo](https://www.apollographql.com/docs/react/api/core/ApolloClient) is a popular GraphQL client for React and other platforms.

--- a/website/versioned_docs/version-0.2.x/guides/interacting/using-relay.md
+++ b/website/versioned_docs/version-0.2.x/guides/interacting/using-relay.md
@@ -1,5 +1,10 @@
 # Using Relay
 
+<head>
+  <meta name="robots" content="noindex" />
+  <meta name="googlebot" content="noindex" />
+</head>
+
 :::tip What is Relay?
 
 [Relay](https://relay.dev/) is a popular GraphQL client for React.

--- a/website/versioned_docs/version-0.2.x/guides/using-composites/customization.mdx
+++ b/website/versioned_docs/version-0.2.x/guides/using-composites/customization.mdx
@@ -3,6 +3,11 @@ import TabItem from '@theme/TabItem'
 
 # Composites customization
 
+<head>
+  <meta name="robots" content="noindex" />
+  <meta name="googlebot" content="noindex" />
+</head>
+
 ## Merging composites
 
 Multiple composites can be merged together into a single composite including all the models from the source composites.

--- a/website/versioned_docs/version-0.2.x/guides/using-composites/deployment.mdx
+++ b/website/versioned_docs/version-0.2.x/guides/using-composites/deployment.mdx
@@ -3,6 +3,11 @@ import TabItem from '@theme/TabItem'
 
 # Composites deployment
 
+<head>
+  <meta name="robots" content="noindex" />
+  <meta name="googlebot" content="noindex" />
+</head>
+
 Valid composites can be deployed to any supporting Ceramic node, by ensuring the model streams described in the composite are available on the node, and that the node is configured to index theses models.
 
 ## Models deployment

--- a/website/versioned_docs/version-0.2.x/guides/using-composites/discovery.mdx
+++ b/website/versioned_docs/version-0.2.x/guides/using-composites/discovery.mdx
@@ -3,6 +3,11 @@ import TabItem from '@theme/TabItem'
 
 # Composites discovery
 
+<head>
+  <meta name="robots" content="noindex" />
+  <meta name="googlebot" content="noindex" />
+</head>
+
 ComposeDB does not yet provide a way to discover composites directly, however it is possible to create composites from known models.
 
 ## Models discovery

--- a/website/versioned_docs/version-0.2.x/guides/using-composites/introduction.md
+++ b/website/versioned_docs/version-0.2.x/guides/using-composites/introduction.md
@@ -1,3 +1,8 @@
 # Using Composites
 
+<head>
+  <meta name="robots" content="noindex" />
+  <meta name="googlebot" content="noindex" />
+</head>
+
 [Composites](../concepts-overview.md#composites) are the primary representation for data models used by ComposeDB. They allow developers to create, share, reuse and combine [models](../concepts-overview.md#models) together in a consistent way.

--- a/website/versioned_docs/version-0.2.x/installation.mdx
+++ b/website/versioned_docs/version-0.2.x/installation.mdx
@@ -1,7 +1,13 @@
 import Tabs from '@theme/Tabs'
 import TabItem from '@theme/TabItem'
 
+
 # Installation
+
+<head>
+  <meta name="robots" content="noindex" />
+  <meta name="googlebot" content="noindex" />
+</head>
 
 :::caution Developer preview
 

--- a/website/versioned_docs/version-0.2.x/introduction.md
+++ b/website/versioned_docs/version-0.2.x/introduction.md
@@ -1,3 +1,8 @@
 # Welcome to ComposeDB
 
+<head>
+  <meta name="robots" content="noindex" />
+  <meta name="googlebot" content="noindex" />
+</head>
+
 ComposeDB on Ceramic is a decentralized, composable graph database. It provides a set of Typescript libraries and tools that allow developers to quickly build applications on [Ceramic](https://ceramic.network/) — including the ability to discover, create, share and reuse composable data models using [GraphQL](https://graphql.org/).

--- a/website/versioned_docs/version-0.3.x/api/classes/client.ComposeClient.md
+++ b/website/versioned_docs/version-0.3.x/api/classes/client.ComposeClient.md
@@ -4,6 +4,11 @@ title: "Class: ComposeClient"
 custom_edit_url: null
 ---
 
+<head>
+  <meta name="robots" content="noindex" />
+  <meta name="googlebot" content="noindex" />
+</head>
+
 [client](../modules/client.md).ComposeClient
 
 The ComposeClient class provides APIs to execute queries on a GraphQL schema generated from a

--- a/website/versioned_docs/version-0.3.x/api/classes/client.Context.md
+++ b/website/versioned_docs/version-0.3.x/api/classes/client.Context.md
@@ -4,6 +4,11 @@ title: "Class: Context"
 custom_edit_url: null
 ---
 
+<head>
+  <meta name="robots" content="noindex" />
+  <meta name="googlebot" content="noindex" />
+</head>
+
 [client](../modules/client.md).Context
 
 GraphQL execution context, exported by the [`client`](../modules/client.md) module.

--- a/website/versioned_docs/version-0.3.x/api/classes/devtools.Composite.md
+++ b/website/versioned_docs/version-0.3.x/api/classes/devtools.Composite.md
@@ -4,6 +4,11 @@ title: "Class: Composite"
 custom_edit_url: null
 ---
 
+<head>
+  <meta name="robots" content="noindex" />
+  <meta name="googlebot" content="noindex" />
+</head>
+
 [devtools](../modules/devtools.md).Composite
 
 The Composite class provides APIs for managing composites (sets of Model streams) through their

--- a/website/versioned_docs/version-0.3.x/api/commands/cli.composite.md
+++ b/website/versioned_docs/version-0.3.x/api/commands/cli.composite.md
@@ -4,6 +4,11 @@ title: "CLI: composite:* commands"
 custom_edit_url: null
 ---
 
+<head>
+  <meta name="robots" content="noindex" />
+  <meta name="googlebot" content="noindex" />
+</head>
+
 The group of [CLI](../modules/cli.md) `composite:*` commands enables the creation and interactions with [Composites](../../guides/concepts-overview.md#composites)
 
 ## Command List

--- a/website/versioned_docs/version-0.3.x/api/commands/cli.did.md
+++ b/website/versioned_docs/version-0.3.x/api/commands/cli.did.md
@@ -4,6 +4,11 @@ title: "CLI: did:* commands"
 custom_edit_url: null
 ---
 
+<head>
+  <meta name="robots" content="noindex" />
+  <meta name="googlebot" content="noindex" />
+</head>
+
 The group of [CLI](../modules/cli.md) `did:*` commands enables interactions with DIDs and private keys
 
 DIDs are identifiers for [Ceramic Accounts](../../guides/concepts-overview.md#accounts)

--- a/website/versioned_docs/version-0.3.x/api/commands/cli.document.md
+++ b/website/versioned_docs/version-0.3.x/api/commands/cli.document.md
@@ -4,6 +4,11 @@ title: "CLI: document:* commands"
 custom_edit_url: null
 ---
 
+<head>
+  <meta name="robots" content="noindex" />
+  <meta name="googlebot" content="noindex" />
+</head>
+
 The group of [CLI](../modules/cli.md) `document:*` commands enables the creation and interactions with [Documents](../../guides/concepts-overview.md#documents)
 
 ## Command List

--- a/website/versioned_docs/version-0.3.x/api/commands/cli.graphql.md
+++ b/website/versioned_docs/version-0.3.x/api/commands/cli.graphql.md
@@ -4,6 +4,11 @@ title: "CLI: graphql:* commands"
 custom_edit_url: null
 ---
 
+<head>
+  <meta name="robots" content="noindex" />
+  <meta name="googlebot" content="noindex" />
+</head>
+
 The group of [CLI](../modules/cli.md) `graphql:*` commands makes it possible to generate GraphQL Schemas from [runtime definitions](./cli.composite.md#composedb-compositecompile) of your [Composites](../../guides/concepts-overview.md#composites) and run a local GraphQL HTTP server
 
 ## Command List

--- a/website/versioned_docs/version-0.3.x/api/commands/cli.model.md
+++ b/website/versioned_docs/version-0.3.x/api/commands/cli.model.md
@@ -4,6 +4,11 @@ title: "CLI: model:* commands"
 custom_edit_url: null
 ---
 
+<head>
+  <meta name="robots" content="noindex" />
+  <meta name="googlebot" content="noindex" />
+</head>
+
 The group of [CLI](../modules/cli.md) `model:*` commands enables discovery of [Models](../../guides/concepts-overview.md#models), as well as their creation and interactions with them
 
 ## Command List

--- a/website/versioned_docs/version-0.3.x/api/index.md
+++ b/website/versioned_docs/version-0.3.x/api/index.md
@@ -5,6 +5,11 @@ hide_table_of_contents: true
 custom_edit_url: null
 ---
 
+<head>
+  <meta name="robots" content="noindex" />
+  <meta name="googlebot" content="noindex" />
+</head>
+
 ## Modules
 
 - [client](modules/client.md)

--- a/website/versioned_docs/version-0.3.x/api/modules/cli.md
+++ b/website/versioned_docs/version-0.3.x/api/modules/cli.md
@@ -4,6 +4,11 @@ title: "Module: CLI"
 custom_edit_url: null
 ---
 
+<head>
+  <meta name="robots" content="noindex" />
+  <meta name="googlebot" content="noindex" />
+</head>
+
 ComposeDB CLI - the Command Line Interface that enables interactions with a Ceramic Node
 
 You can check the [Getting Started](../../first-composite.mdx) Section for some examples (remember to switch to the 'Using the CLI' tab!)

--- a/website/versioned_docs/version-0.3.x/api/modules/client.md
+++ b/website/versioned_docs/version-0.3.x/api/modules/client.md
@@ -4,6 +4,11 @@ title: "Module: client"
 custom_edit_url: null
 ---
 
+<head>
+  <meta name="robots" content="noindex" />
+  <meta name="googlebot" content="noindex" />
+</head>
+
 ComposeDB client.
 
 ## Installation

--- a/website/versioned_docs/version-0.3.x/api/modules/devtools.md
+++ b/website/versioned_docs/version-0.3.x/api/modules/devtools.md
@@ -4,6 +4,11 @@ title: "Module: devtools"
 custom_edit_url: null
 ---
 
+<head>
+  <meta name="robots" content="noindex" />
+  <meta name="googlebot" content="noindex" />
+</head>
+
 Development tools library.
 
 ## Installation

--- a/website/versioned_docs/version-0.3.x/api/modules/devtools_node.md
+++ b/website/versioned_docs/version-0.3.x/api/modules/devtools_node.md
@@ -4,6 +4,11 @@ title: "Module: devtools-node"
 custom_edit_url: null
 ---
 
+<head>
+  <meta name="robots" content="noindex" />
+  <meta name="googlebot" content="noindex" />
+</head>
+
 Node.js-specific development tools.
 
 ## Installation

--- a/website/versioned_docs/version-0.3.x/client-setup.mdx
+++ b/website/versioned_docs/version-0.3.x/client-setup.mdx
@@ -3,6 +3,11 @@ import TabItem from '@theme/TabItem'
 
 # Client setup
 
+<head>
+  <meta name="robots" content="noindex" />
+  <meta name="googlebot" content="noindex" />
+</head>
+
 ## Compiling the composite
 
 In order to interact with a composite at runtime, it is first necessary to create a runtime composite definition file that will be used to configure the client.

--- a/website/versioned_docs/version-0.3.x/configuration.mdx
+++ b/website/versioned_docs/version-0.3.x/configuration.mdx
@@ -3,6 +3,11 @@ import TabItem from '@theme/TabItem'
 
 # Ceramic configuration
 
+<head>
+  <meta name="robots" content="noindex" />
+  <meta name="googlebot" content="noindex" />
+</head>
+
 Ceramic functionalities supporting ComposeDB are currently considered
 experimental and the Ceramic node must be explicitly configured to support them.
 

--- a/website/versioned_docs/version-0.3.x/first-composite.mdx
+++ b/website/versioned_docs/version-0.3.x/first-composite.mdx
@@ -3,6 +3,11 @@ import TabItem from '@theme/TabItem'
 
 # Your first composite
 
+<head>
+  <meta name="robots" content="noindex" />
+  <meta name="googlebot" content="noindex" />
+</head>
+
 ComposeDB provides an abstraction on top of Ceramic streams by leveraging composites, an internal data structure referencing Ceramic model streams and associated metadata. Most of ComposeDB tools and clients interact with various representations of composites.
 
 This page presents how to create your first composite and deploy it to your local Ceramic node, in order to interact with documents on Ceramic.

--- a/website/versioned_docs/version-0.3.x/guides/concepts-overview.md
+++ b/website/versioned_docs/version-0.3.x/guides/concepts-overview.md
@@ -1,5 +1,10 @@
 # Concepts overview
 
+<head>
+  <meta name="robots" content="noindex" />
+  <meta name="googlebot" content="noindex" />
+</head>
+
 ComposeDB provides a **graph structure** for interacting with data on the
 [Ceramic network](https://ceramic.network/).
 

--- a/website/versioned_docs/version-0.3.x/guides/creating-composites/directives.md
+++ b/website/versioned_docs/version-0.3.x/guides/creating-composites/directives.md
@@ -1,5 +1,10 @@
 # Supported directives
 
+<head>
+  <meta name="robots" content="noindex" />
+  <meta name="googlebot" content="noindex" />
+</head>
+
 Directives provide extra metadata when declaring scalars, lists and shapes.
 
 ## Model identification

--- a/website/versioned_docs/version-0.3.x/guides/creating-composites/overview.mdx
+++ b/website/versioned_docs/version-0.3.x/guides/creating-composites/overview.mdx
@@ -3,6 +3,11 @@ import TabItem from '@theme/TabItem'
 
 # Creating Composites
 
+<head>
+  <meta name="robots" content="noindex" />
+  <meta name="googlebot" content="noindex" />
+</head>
+
 Composites are the abstraction ComposeDB tools and client use to represent and manipulate data models used by applications.
 
 In order to create new composites, especially to create new models that do not already exist on the Ceramic network, a high-level schema can be used as an abstraction for the composite structure.

--- a/website/versioned_docs/version-0.3.x/guides/creating-composites/scalars.md
+++ b/website/versioned_docs/version-0.3.x/guides/creating-composites/scalars.md
@@ -1,5 +1,10 @@
 # Supported scalars
 
+<head>
+  <meta name="robots" content="noindex" />
+  <meta name="googlebot" content="noindex" />
+</head>
+
 Scalars represent the leaf values in the graph, either as part of key-value
 properties in shapes, or value of items in lists. You can learn more about
 scalars in the

--- a/website/versioned_docs/version-0.3.x/guides/creating-composites/schema.md
+++ b/website/versioned_docs/version-0.3.x/guides/creating-composites/schema.md
@@ -1,5 +1,10 @@
 # Schema definition
 
+<head>
+  <meta name="robots" content="noindex" />
+  <meta name="googlebot" content="noindex" />
+</head>
+
 Composite schemas are based on [GraphQL's Schema Definition Language](https://graphql.org/learn/schema/), using a subset of functionalities offered by GraphQL to describe models used by ComposeDB.
 
 ## Schema Definition Language

--- a/website/versioned_docs/version-0.3.x/guides/data-composition.mdx
+++ b/website/versioned_docs/version-0.3.x/guides/data-composition.mdx
@@ -3,6 +3,11 @@ import ThemedImage from '@theme/ThemedImage'
 
 # Data composition
 
+<head>
+  <meta name="robots" content="noindex" />
+  <meta name="googlebot" content="noindex" />
+</head>
+
 Data composition is at the heart of ComposeDB, using [composites](./concepts-overview.md#composites) as a proxy for datasets of [documents](./concepts-overview.md#documents) relevant to applications and services.
 
 Composites represent sets of [models](./concepts-overview.md#models) that can be used to query, create and update documents, therefore it is important for developers to identify models to use, whether by [reusing models already adopted by the ecosystem](./using-composites/discovery.mdx) in order to access the set of documents already created using these models, or [creating new models](./creating-composites/overview.mdx) that would better suit specific needs.

--- a/website/versioned_docs/version-0.3.x/guides/index.mdx
+++ b/website/versioned_docs/version-0.3.x/guides/index.mdx
@@ -3,4 +3,9 @@ import { useCurrentSidebarCategory } from '@docusaurus/theme-common'
 
 # Guides
 
+<head>
+  <meta name="robots" content="noindex" />
+  <meta name="googlebot" content="noindex" />
+</head>
+
 <DocCardList items={useCurrentSidebarCategory().items} />

--- a/website/versioned_docs/version-0.3.x/guides/interacting/mutations.mdx
+++ b/website/versioned_docs/version-0.3.x/guides/interacting/mutations.mdx
@@ -1,5 +1,10 @@
 # Performing mutations
 
+<head>
+  <meta name="robots" content="noindex" />
+  <meta name="googlebot" content="noindex" />
+</head>
+
 ## Enabling mutations
 
 In order to perform mutations, the Ceramic instance used by the ComposeDB client needs to be authenticated. This can be done by calling the [`setDID` method](../../api/classes/client.ComposeClient.md#setdid) on the [`ComposeClient`](../../api/classes/client.ComposeClient.md) instance with an authenticated `DID` instance:

--- a/website/versioned_docs/version-0.3.x/guides/interacting/queries.md
+++ b/website/versioned_docs/version-0.3.x/guides/interacting/queries.md
@@ -1,5 +1,10 @@
 # Querying the graph
 
+<head>
+  <meta name="robots" content="noindex" />
+  <meta name="googlebot" content="noindex" />
+</head>
+
 The [`ComposeClient`](../../api/classes/client.ComposeClient.md) automatically generates a GraphQL Schema from the runtime composite definition.
 
 It notablly creates a [`CeramicAccount` object](#ceramicaccount-object) that replaces [`DID` scalar](../creating-composites/scalars.md#did) representations, and the root [`Query` object](#query-object) used as an entry-point to acces the graph.

--- a/website/versioned_docs/version-0.3.x/guides/interacting/using-apollo.md
+++ b/website/versioned_docs/version-0.3.x/guides/interacting/using-apollo.md
@@ -1,5 +1,10 @@
 # Using Apollo
 
+<head>
+  <meta name="robots" content="noindex" />
+  <meta name="googlebot" content="noindex" />
+</head>
+
 :::tip What is Apollo?
 
 [Apollo](https://www.apollographql.com/docs/react/api/core/ApolloClient) is a popular GraphQL client for React and other platforms.

--- a/website/versioned_docs/version-0.3.x/guides/interacting/using-relay.md
+++ b/website/versioned_docs/version-0.3.x/guides/interacting/using-relay.md
@@ -1,5 +1,10 @@
 # Using Relay
 
+<head>
+  <meta name="robots" content="noindex" />
+  <meta name="googlebot" content="noindex" />
+</head>
+
 :::tip What is Relay?
 
 [Relay](https://relay.dev/) is a popular GraphQL client for React.

--- a/website/versioned_docs/version-0.3.x/guides/using-composites/customization.mdx
+++ b/website/versioned_docs/version-0.3.x/guides/using-composites/customization.mdx
@@ -3,6 +3,11 @@ import TabItem from '@theme/TabItem'
 
 # Composites customization
 
+<head>
+  <meta name="robots" content="noindex" />
+  <meta name="googlebot" content="noindex" />
+</head>
+
 ## Merging composites
 
 Multiple composites can be merged together into a single composite including all the models from the source composites.

--- a/website/versioned_docs/version-0.3.x/guides/using-composites/deployment.mdx
+++ b/website/versioned_docs/version-0.3.x/guides/using-composites/deployment.mdx
@@ -3,6 +3,11 @@ import TabItem from '@theme/TabItem'
 
 # Composites deployment
 
+<head>
+  <meta name="robots" content="noindex" />
+  <meta name="googlebot" content="noindex" />
+</head>
+
 Valid composites can be deployed to any supporting Ceramic node, by ensuring
 the model streams described in the composite are available and indexed on the
 node. An [admin DID](../../configuration.mdx#admin-dids) is necessary to start

--- a/website/versioned_docs/version-0.3.x/guides/using-composites/discovery.mdx
+++ b/website/versioned_docs/version-0.3.x/guides/using-composites/discovery.mdx
@@ -3,6 +3,11 @@ import TabItem from '@theme/TabItem'
 
 # Composites discovery
 
+<head>
+  <meta name="robots" content="noindex" />
+  <meta name="googlebot" content="noindex" />
+</head>
+
 ComposeDB does not yet provide a way to discover composites directly, however it is possible to create composites from known models.
 
 ## Models discovery

--- a/website/versioned_docs/version-0.3.x/guides/using-composites/introduction.md
+++ b/website/versioned_docs/version-0.3.x/guides/using-composites/introduction.md
@@ -1,3 +1,8 @@
 # Using Composites
 
+<head>
+  <meta name="robots" content="noindex" />
+  <meta name="googlebot" content="noindex" />
+</head>
+
 [Composites](../concepts-overview.md#composites) are the primary representation for data models used by ComposeDB. They allow developers to create, share, reuse and combine [models](../concepts-overview.md#models) together in a consistent way.

--- a/website/versioned_docs/version-0.3.x/installation.mdx
+++ b/website/versioned_docs/version-0.3.x/installation.mdx
@@ -3,6 +3,11 @@ import TabItem from '@theme/TabItem'
 
 # Installation
 
+<head>
+  <meta name="robots" content="noindex" />
+  <meta name="googlebot" content="noindex" />
+</head>
+
 :::caution Developer preview
 
 ComposeDB packages are still under development and only released as a developer preview, they are **not ready for production use**.

--- a/website/versioned_docs/version-0.3.x/introduction.md
+++ b/website/versioned_docs/version-0.3.x/introduction.md
@@ -1,4 +1,10 @@
 # ComposeDB Docs
+
+<head>
+  <meta name="robots" content="noindex" />
+  <meta name="googlebot" content="noindex" />
+</head>
+
 ![Introduction](/img/intro-dataverse.png)
 
 ComposeDB on Ceramic is a decentralized, composable graph database! It provides a set of Typescript libraries and tools that allow developers to rapidly build applications on [Ceramic](https://ceramic.network/) — including the ability to discover, create, share and reuse composable data models using [GraphQL](https://www.graphql.org/).

--- a/website/versioned_docs/version-0.4.x/api/classes/client.ComposeClient.md
+++ b/website/versioned_docs/version-0.4.x/api/classes/client.ComposeClient.md
@@ -4,6 +4,11 @@ title: "Class: ComposeClient"
 custom_edit_url: null
 ---
 
+<head>
+  <meta name="robots" content="noindex" />
+  <meta name="googlebot" content="noindex" />
+</head>
+
 [client](../modules/client.md).ComposeClient
 
 The ComposeClient class provides APIs to execute queries on a GraphQL schema generated from a

--- a/website/versioned_docs/version-0.4.x/api/classes/devtools.Composite.md
+++ b/website/versioned_docs/version-0.4.x/api/classes/devtools.Composite.md
@@ -4,6 +4,11 @@ title: "Class: Composite"
 custom_edit_url: null
 ---
 
+<head>
+  <meta name="robots" content="noindex" />
+  <meta name="googlebot" content="noindex" />
+</head>
+
 [devtools](../modules/devtools.md).Composite
 
 The Composite class provides APIs for managing composites (sets of Model streams) through their

--- a/website/versioned_docs/version-0.4.x/api/classes/runtime.ComposeRuntime.md
+++ b/website/versioned_docs/version-0.4.x/api/classes/runtime.ComposeRuntime.md
@@ -4,6 +4,11 @@ title: "Class: ComposeRuntime"
 custom_edit_url: null
 ---
 
+<head>
+  <meta name="robots" content="noindex" />
+  <meta name="googlebot" content="noindex" />
+</head>
+
 [runtime](../modules/runtime.md).ComposeRuntime
 
 The ComposeRuntime class provides APIs to execute queries on a GraphQL schema generated from a

--- a/website/versioned_docs/version-0.4.x/api/commands/cli.composite.md
+++ b/website/versioned_docs/version-0.4.x/api/commands/cli.composite.md
@@ -4,6 +4,11 @@ title: "CLI: composite:* commands"
 custom_edit_url: null
 ---
 
+<head>
+  <meta name="robots" content="noindex" />
+  <meta name="googlebot" content="noindex" />
+</head>
+
 The group of [CLI](../modules/cli.md) `composite:*` commands enables the
 creation and interactions with [Composites](../../guides/data-modeling/composites.mdx)
 

--- a/website/versioned_docs/version-0.4.x/api/commands/cli.did.md
+++ b/website/versioned_docs/version-0.4.x/api/commands/cli.did.md
@@ -4,6 +4,11 @@ title: "CLI: did:* commands"
 custom_edit_url: null
 ---
 
+<head>
+  <meta name="robots" content="noindex" />
+  <meta name="googlebot" content="noindex" />
+</head>
+
 The group of [CLI](../modules/cli.md) `did:*` commands enables interactions with DIDs and private keys
 
 DIDs are identifiers for [Ceramic Accounts](../../core-concepts.mdx#accounts)

--- a/website/versioned_docs/version-0.4.x/api/commands/cli.document.md
+++ b/website/versioned_docs/version-0.4.x/api/commands/cli.document.md
@@ -4,6 +4,11 @@ title: "CLI: document:* commands"
 custom_edit_url: null
 ---
 
+<head>
+  <meta name="robots" content="noindex" />
+  <meta name="googlebot" content="noindex" />
+</head>
+
 The group of [CLI](../modules/cli.md) `document:*` commands enables the creation and interactions with [Documents](../../core-concepts.mdx#documents)
 
 ## Command List

--- a/website/versioned_docs/version-0.4.x/api/commands/cli.graphql.md
+++ b/website/versioned_docs/version-0.4.x/api/commands/cli.graphql.md
@@ -4,6 +4,11 @@ title: "CLI: graphql:* commands"
 custom_edit_url: null
 ---
 
+<head>
+  <meta name="robots" content="noindex" />
+  <meta name="googlebot" content="noindex" />
+</head>
+
 The group of [CLI](../modules/cli.md) `graphql:*` commands makes it possible to generate GraphQL Schemas from compiled [Composites](../../guides/data-modeling/composites.mdx) and run a local GraphQL HTTP server
 
 ## Command List

--- a/website/versioned_docs/version-0.4.x/api/commands/cli.model.md
+++ b/website/versioned_docs/version-0.4.x/api/commands/cli.model.md
@@ -4,6 +4,11 @@ title: "CLI: model:* commands"
 custom_edit_url: null
 ---
 
+<head>
+  <meta name="robots" content="noindex" />
+  <meta name="googlebot" content="noindex" />
+</head>
+
 The group of [CLI](../modules/cli.md) `model:*` commands enables discovery of [Models](../../core-concepts.mdx#models), as well as their creation and interactions with them.
 
 ## Command List

--- a/website/versioned_docs/version-0.4.x/api/index.md
+++ b/website/versioned_docs/version-0.4.x/api/index.md
@@ -5,6 +5,11 @@ hide_table_of_contents: true
 custom_edit_url: null
 ---
 
+<head>
+  <meta name="robots" content="noindex" />
+  <meta name="googlebot" content="noindex" />
+</head>
+
 ## Modules
 
 - [client](modules/client.md)

--- a/website/versioned_docs/version-0.4.x/api/modules/cli.md
+++ b/website/versioned_docs/version-0.4.x/api/modules/cli.md
@@ -4,6 +4,11 @@ title: "Module: CLI"
 custom_edit_url: null
 ---
 
+<head>
+  <meta name="robots" content="noindex" />
+  <meta name="googlebot" content="noindex" />
+</head>
+
 ComposeDB CLI - the Command Line Interface that enables interactions with a Ceramic Node
 
 You can check the [Getting Started](../../set-up-your-environment.mdx) Section for some examples.

--- a/website/versioned_docs/version-0.4.x/api/modules/client.md
+++ b/website/versioned_docs/version-0.4.x/api/modules/client.md
@@ -4,6 +4,11 @@ title: "Module: client"
 custom_edit_url: null
 ---
 
+<head>
+  <meta name="robots" content="noindex" />
+  <meta name="googlebot" content="noindex" />
+</head>
+
 High-level ComposeDB client, based on the [`ComposeDB runtime`](runtime.md).
 
 ## Installation

--- a/website/versioned_docs/version-0.4.x/api/modules/devtools.md
+++ b/website/versioned_docs/version-0.4.x/api/modules/devtools.md
@@ -4,6 +4,11 @@ title: "Module: devtools"
 custom_edit_url: null
 ---
 
+<head>
+  <meta name="robots" content="noindex" />
+  <meta name="googlebot" content="noindex" />
+</head>
+
 Development tools library.
 
 ## Installation

--- a/website/versioned_docs/version-0.4.x/api/modules/devtools_node.md
+++ b/website/versioned_docs/version-0.4.x/api/modules/devtools_node.md
@@ -4,6 +4,11 @@ title: "Module: devtools-node"
 custom_edit_url: null
 ---
 
+<head>
+  <meta name="robots" content="noindex" />
+  <meta name="googlebot" content="noindex" />
+</head>
+
 Node.js-specific development tools.
 
 ## Installation

--- a/website/versioned_docs/version-0.4.x/api/modules/runtime.md
+++ b/website/versioned_docs/version-0.4.x/api/modules/runtime.md
@@ -4,6 +4,11 @@ title: "Module: runtime"
 custom_edit_url: null
 ---
 
+<head>
+  <meta name="robots" content="noindex" />
+  <meta name="googlebot" content="noindex" />
+</head>
+
 ComposeDB runtime module, converting a runtime composite to an executable GraphQL schema.
 
 ## Installation

--- a/website/versioned_docs/version-0.4.x/api/modules/server.md
+++ b/website/versioned_docs/version-0.4.x/api/modules/server.md
@@ -4,6 +4,11 @@ title: "Module: server"
 custom_edit_url: null
 ---
 
+<head>
+  <meta name="robots" content="noindex" />
+  <meta name="googlebot" content="noindex" />
+</head>
+
 ComposeDB server for hybrid execution on the [`ComposeDB client`](client.md).
 
 ## Installation

--- a/website/versioned_docs/version-0.4.x/api/sdl/directives.mdx
+++ b/website/versioned_docs/version-0.4.x/api/sdl/directives.mdx
@@ -1,5 +1,10 @@
 # Supported directives
 
+<head>
+  <meta name="robots" content="noindex" />
+  <meta name="googlebot" content="noindex" />
+</head>
+
 Directives provide extra metadata when declaring scalars, lists and shapes.
 
 ## Model identification

--- a/website/versioned_docs/version-0.4.x/api/sdl/scalars.mdx
+++ b/website/versioned_docs/version-0.4.x/api/sdl/scalars.mdx
@@ -1,5 +1,10 @@
 # Supported scalars
 
+<head>
+  <meta name="robots" content="noindex" />
+  <meta name="googlebot" content="noindex" />
+</head>
+
 Scalars represent the leaf values in the graph, either as part of key-value
 properties in shapes, or value of items in lists. You can learn more about
 scalars in the

--- a/website/versioned_docs/version-0.4.x/ceramic-roadmap.mdx
+++ b/website/versioned_docs/version-0.4.x/ceramic-roadmap.mdx
@@ -1,5 +1,10 @@
 # ComposeDB roadmap
 
+<head>
+  <meta name="robots" content="noindex" />
+  <meta name="googlebot" content="noindex" />
+</head>
+
 Since the launch of the ComposeDB Beta, the core Ceramic team remains committed to making ongoing improvements
 to both ComposeDB and the underlying Ceramic protocol. Concurrently, we seek to involve the Ceramic developer
 community in shaping Ceramic's future. We value your active participation in helping us prioritize the features 

--- a/website/versioned_docs/version-0.4.x/community.mdx
+++ b/website/versioned_docs/version-0.4.x/community.mdx
@@ -1,4 +1,10 @@
 # Community
+
+<head>
+  <meta name="robots" content="noindex" />
+  <meta name="googlebot" content="noindex" />
+</head>
+
 Explore the many ways to connect, learn, and participate in the ComposeDB community.
 
 ## Chat and Discussion

--- a/website/versioned_docs/version-0.4.x/core-concepts.mdx
+++ b/website/versioned_docs/version-0.4.x/core-concepts.mdx
@@ -1,4 +1,10 @@
 # ComposeDB Concepts
+
+<head>
+  <meta name="robots" content="noindex" />
+  <meta name="googlebot" content="noindex" />
+</head>
+
 Learn about the ComposeDB graph database protocol and technology stack.
 
 ## Graph Database Protocol

--- a/website/versioned_docs/version-0.4.x/create-your-composite.mdx
+++ b/website/versioned_docs/version-0.4.x/create-your-composite.mdx
@@ -1,5 +1,10 @@
 # Create your composite
 
+<head>
+  <meta name="robots" content="noindex" />
+  <meta name="googlebot" content="noindex" />
+</head>
+
 Create your composite to serve as your graph database schema. In this guide, we will create your first composite.
 
 :::tip

--- a/website/versioned_docs/version-0.4.x/getting-started.mdx
+++ b/website/versioned_docs/version-0.4.x/getting-started.mdx
@@ -1,6 +1,12 @@
 import DocCardList from '@theme/DocCardList';
 
 # Getting Started
+
+<head>
+  <meta name="robots" content="noindex" />
+  <meta name="googlebot" content="noindex" />
+</head>
+
 Learn the basics of ComposeDB by quickly building a “Hello World” social application. 
 
 ![Getting Started](/img/getting-started-img.png)

--- a/website/versioned_docs/version-0.4.x/guides/composedb-client/authenticate-users.mdx
+++ b/website/versioned_docs/version-0.4.x/guides/composedb-client/authenticate-users.mdx
@@ -1,4 +1,10 @@
 # Authenticate Users
+
+<head>
+  <meta name="robots" content="noindex" />
+  <meta name="googlebot" content="noindex" />
+</head>
+
 Set up authentication for your ComposeDB application.
 
 ## Introduction

--- a/website/versioned_docs/version-0.4.x/guides/composedb-client/composedb-client.mdx
+++ b/website/versioned_docs/version-0.4.x/guides/composedb-client/composedb-client.mdx
@@ -1,5 +1,10 @@
 # ComposeDB Client
 
+<head>
+  <meta name="robots" content="noindex" />
+  <meta name="googlebot" content="noindex" />
+</head>
+
 Connect your app to a ComposeDB server
 
 ## Connect your application

--- a/website/versioned_docs/version-0.4.x/guides/composedb-client/javascript-client.mdx
+++ b/website/versioned_docs/version-0.4.x/guides/composedb-client/javascript-client.mdx
@@ -3,6 +3,12 @@ import TabItem from '@theme/TabItem'
 import DocCardList from '@theme/DocCardList';
 
 # JavaScript Client
+
+<head>
+  <meta name="robots" content="noindex" />
+  <meta name="googlebot" content="noindex" />
+</head>
+
 APIs to interact with ComposeDB from JavaScript, TypeScript, or React. 
 
 ## Prerequisites

--- a/website/versioned_docs/version-0.4.x/guides/composedb-client/user-sessions.mdx
+++ b/website/versioned_docs/version-0.4.x/guides/composedb-client/user-sessions.mdx
@@ -3,6 +3,11 @@ import TabItem from '@theme/TabItem'
 
 # User Sessions
 
+<head>
+  <meta name="robots" content="noindex" />
+  <meta name="googlebot" content="noindex" />
+</head>
+
 Create authenticated sessions for users with great UX.
 
 ## About Sessions

--- a/website/versioned_docs/version-0.4.x/guides/composedb-client/using-apollo.mdx
+++ b/website/versioned_docs/version-0.4.x/guides/composedb-client/using-apollo.mdx
@@ -1,4 +1,10 @@
 # Using Apollo GraphQL Client
+
+<head>
+  <meta name="robots" content="noindex" />
+  <meta name="googlebot" content="noindex" />
+</head>
+
 [Apollo](https://www.apollographql.com/docs/react/api/core/ApolloClient) is a popular GraphQL client for React and other platforms.
 
 ## Prerequisites

--- a/website/versioned_docs/version-0.4.x/guides/composedb-client/using-relay.mdx
+++ b/website/versioned_docs/version-0.4.x/guides/composedb-client/using-relay.mdx
@@ -1,4 +1,10 @@
 # Using Relay GraphQL Client
+
+<head>
+  <meta name="robots" content="noindex" />
+  <meta name="googlebot" content="noindex" />
+</head>
+
 [Relay](https://relay.dev/) is a popular GraphQL client for React.
 
 ## Prerequisites

--- a/website/versioned_docs/version-0.4.x/guides/composedb-server/access-mainnet.mdx
+++ b/website/versioned_docs/version-0.4.x/guides/composedb-server/access-mainnet.mdx
@@ -1,5 +1,10 @@
 # Access Ceramic Mainnet
 
+<head>
+  <meta name="robots" content="noindex" />
+  <meta name="googlebot" content="noindex" />
+</head>
+
 To join mainnet, you must register your Ceramic node with the 3Box Labs’ Ceramic Anchor Service (CAS). The job of CAS is to anchor Ceramic streams on the Ethereum blockchain so your node will not work without access to CAS.
 
 To register you will need (1) a valid email address and (2) the DID used by your Ceramic daemon.

--- a/website/versioned_docs/version-0.4.x/guides/composedb-server/composedb-server.mdx
+++ b/website/versioned_docs/version-0.4.x/guides/composedb-server/composedb-server.mdx
@@ -1,4 +1,10 @@
 # ComposeDB Server
+
+<head>
+  <meta name="robots" content="noindex" />
+  <meta name="googlebot" content="noindex" />
+</head>
+
 Set up and run a ComposeDB Server
 
 ## Running locally

--- a/website/versioned_docs/version-0.4.x/guides/composedb-server/data-storage.mdx
+++ b/website/versioned_docs/version-0.4.x/guides/composedb-server/data-storage.mdx
@@ -1,4 +1,10 @@
 # Data Storage
+
+<head>
+  <meta name="robots" content="noindex" />
+  <meta name="googlebot" content="noindex" />
+</head>
+
 Store and remove data from your node
 
 ## Overview

--- a/website/versioned_docs/version-0.4.x/guides/composedb-server/running-in-the-cloud.mdx
+++ b/website/versioned_docs/version-0.4.x/guides/composedb-server/running-in-the-cloud.mdx
@@ -1,4 +1,10 @@
 # Running in the Cloud
+
+<head>
+  <meta name="robots" content="noindex" />
+  <meta name="googlebot" content="noindex" />
+</head>
+
 Run a ComposeDB server in the cloud
 
 ## Things to Know

--- a/website/versioned_docs/version-0.4.x/guides/composedb-server/running-locally.mdx
+++ b/website/versioned_docs/version-0.4.x/guides/composedb-server/running-locally.mdx
@@ -1,4 +1,10 @@
 # Running Locally
+
+<head>
+  <meta name="robots" content="noindex" />
+  <meta name="googlebot" content="noindex" />
+</head>
+
 Run a ComposeDB server on your local machine, e.g. your laptop
 
 ## Things to Know

--- a/website/versioned_docs/version-0.4.x/guides/composedb-server/server-configurations.mdx
+++ b/website/versioned_docs/version-0.4.x/guides/composedb-server/server-configurations.mdx
@@ -2,6 +2,12 @@ import Tabs from '@theme/Tabs'
 import TabItem from '@theme/TabItem'
 
 # Server Configurations
+
+<head>
+  <meta name="robots" content="noindex" />
+  <meta name="googlebot" content="noindex" />
+</head>
+
 Manage the configurations for your ComposeDB server.
 
 ## Default configurations

--- a/website/versioned_docs/version-0.4.x/guides/data-interactions/data-interactions.mdx
+++ b/website/versioned_docs/version-0.4.x/guides/data-interactions/data-interactions.mdx
@@ -1,4 +1,10 @@
 # Data Interactions
+
+<head>
+  <meta name="robots" content="noindex" />
+  <meta name="googlebot" content="noindex" />
+</head>
+
 Query and mutate data on ComposeDB.
 
 ## Overview

--- a/website/versioned_docs/version-0.4.x/guides/data-interactions/mutations.mdx
+++ b/website/versioned_docs/version-0.4.x/guides/data-interactions/mutations.mdx
@@ -3,6 +3,11 @@ import TabItem from '@theme/TabItem'
 
 # Mutations
 
+<head>
+  <meta name="robots" content="noindex" />
+  <meta name="googlebot" content="noindex" />
+</head>
+
 Create or update data on ComposeDB.
 
 ## Prerequisites

--- a/website/versioned_docs/version-0.4.x/guides/data-interactions/queries.mdx
+++ b/website/versioned_docs/version-0.4.x/guides/data-interactions/queries.mdx
@@ -1,5 +1,10 @@
 # Queries
 
+<head>
+  <meta name="robots" content="noindex" />
+  <meta name="googlebot" content="noindex" />
+</head>
+
 Access data stored on the network.
 
 ## Prerequisites

--- a/website/versioned_docs/version-0.4.x/guides/data-modeling/composites.mdx
+++ b/website/versioned_docs/version-0.4.x/guides/data-modeling/composites.mdx
@@ -2,6 +2,12 @@ import Tabs from '@theme/Tabs'
 import TabItem from '@theme/TabItem'
 
 # Composites
+
+<head>
+  <meta name="robots" content="noindex" />
+  <meta name="googlebot" content="noindex" />
+</head>
+
 Guides for creating, deploying, and using composites.
 
 ## Overview

--- a/website/versioned_docs/version-0.4.x/guides/data-modeling/data-modeling.mdx
+++ b/website/versioned_docs/version-0.4.x/guides/data-modeling/data-modeling.mdx
@@ -2,6 +2,11 @@ import DocCardList from '@theme/DocCardList';
 
 # Data Modeling
 
+<head>
+  <meta name="robots" content="noindex" />
+  <meta name="googlebot" content="noindex" />
+</head>
+
 Learn how to model data for ComposeDB.
 
 ## Overview

--- a/website/versioned_docs/version-0.4.x/guides/data-modeling/introduction-to-modeling.mdx
+++ b/website/versioned_docs/version-0.4.x/guides/data-modeling/introduction-to-modeling.mdx
@@ -2,6 +2,12 @@
 Learn the basics of creating a new data model.
 
 ## Setup
+
+<head>
+  <meta name="robots" content="noindex" />
+  <meta name="googlebot" content="noindex" />
+</head>
+
 ---
 Create a new `.graphql` file in your project directory to store your model(s). 
 

--- a/website/versioned_docs/version-0.4.x/guides/data-modeling/model-catalog.mdx
+++ b/website/versioned_docs/version-0.4.x/guides/data-modeling/model-catalog.mdx
@@ -1,4 +1,10 @@
 # Model Catalog
+
+<head>
+  <meta name="robots" content="noindex" />
+  <meta name="googlebot" content="noindex" />
+</head>
+
 Discover, share, and reuse data models.
 
 ## Overview

--- a/website/versioned_docs/version-0.4.x/guides/data-modeling/relations-combine-items.mdx
+++ b/website/versioned_docs/version-0.4.x/guides/data-modeling/relations-combine-items.mdx
@@ -1,5 +1,10 @@
 # Example: Container of Items
 
+<head>
+  <meta name="robots" content="noindex" />
+  <meta name="googlebot" content="noindex" />
+</head>
+
 ## Creating the Models
 First, create the SDL for the first model to be combined
 

--- a/website/versioned_docs/version-0.4.x/guides/data-modeling/relations-container-of-items.mdx
+++ b/website/versioned_docs/version-0.4.x/guides/data-modeling/relations-container-of-items.mdx
@@ -1,5 +1,10 @@
 # Example: Container of Items
 
+<head>
+  <meta name="robots" content="noindex" />
+  <meta name="googlebot" content="noindex" />
+</head>
+
 ## Creating the Models
 First, create the SDL for your item
 

--- a/website/versioned_docs/version-0.4.x/guides/data-modeling/relations.mdx
+++ b/website/versioned_docs/version-0.4.x/guides/data-modeling/relations.mdx
@@ -1,4 +1,10 @@
 # Relations
+
+<head>
+  <meta name="robots" content="noindex" />
+  <meta name="googlebot" content="noindex" />
+</head>
+
 Define queryable relationships between models and other models or accounts.
 
 ## Types of Relations

--- a/website/versioned_docs/version-0.4.x/guides/data-modeling/schemas.mdx
+++ b/website/versioned_docs/version-0.4.x/guides/data-modeling/schemas.mdx
@@ -1,5 +1,10 @@
 # Schemas
 
+<head>
+  <meta name="robots" content="noindex" />
+  <meta name="googlebot" content="noindex" />
+</head>
+
 Learn how to write high-quality GraphQL schemas for your models.
 
 ## Overview

--- a/website/versioned_docs/version-0.4.x/guides/data-modeling/writing-models.mdx
+++ b/website/versioned_docs/version-0.4.x/guides/data-modeling/writing-models.mdx
@@ -1,4 +1,10 @@
 # Writing Models
+
+<head>
+  <meta name="robots" content="noindex" />
+  <meta name="googlebot" content="noindex" />
+</head>
+
 Create new models or extend existing models.
 
 ## Introduction to Modeling

--- a/website/versioned_docs/version-0.4.x/guides/index.mdx
+++ b/website/versioned_docs/version-0.4.x/guides/index.mdx
@@ -1,5 +1,10 @@
 # ComposeDB Development Guides
 
+<head>
+  <meta name="robots" content="noindex" />
+  <meta name="googlebot" content="noindex" />
+</head>
+
 ### [Data Modeling →](./data-modeling/data-modeling.mdx)
 Learn how to model data for ComposeDB.
 

--- a/website/versioned_docs/version-0.4.x/interact-with-data.mdx
+++ b/website/versioned_docs/version-0.4.x/interact-with-data.mdx
@@ -3,6 +3,12 @@ import TabItem from '@theme/TabItem'
 
 
 # Interact with data
+
+<head>
+  <meta name="robots" content="noindex" />
+  <meta name="googlebot" content="noindex" />
+</head>
+
 The final step of getting started with ComposeDB is interacting with your data using GraphQL. In this guide you will learn how to perform GraphQL queries and mutations using your composite.
 
 :::tip

--- a/website/versioned_docs/version-0.4.x/introduction.mdx
+++ b/website/versioned_docs/version-0.4.x/introduction.mdx
@@ -1,4 +1,10 @@
 # ComposeDB Docs
+
+<head>
+  <meta name="robots" content="noindex" />
+  <meta name="googlebot" content="noindex" />
+</head>
+
 ![Introduction](/img/intro-dataverse.png)
 
 ComposeDB is a composable graph database built on [Ceramic](https://ceramic.network), designed for Web3 applications. 

--- a/website/versioned_docs/version-0.4.x/next-steps.mdx
+++ b/website/versioned_docs/version-0.4.x/next-steps.mdx
@@ -3,6 +3,11 @@ import TabItem from '@theme/TabItem'
 
 # Next Steps
 
+<head>
+  <meta name="robots" content="noindex" />
+  <meta name="googlebot" content="noindex" />
+</head>
+
 After learning the foundations of ComposeDB with the [Getting Started](./getting-started.mdx) guide, you are now ready to start integrating ComposeDB into your application and run in production.
 
 ## Integration Guides

--- a/website/versioned_docs/version-0.4.x/set-up-your-environment.mdx
+++ b/website/versioned_docs/version-0.4.x/set-up-your-environment.mdx
@@ -3,6 +3,11 @@ import TabItem from '@theme/TabItem'
 
 # Set up your environment
 
+<head>
+  <meta name="robots" content="noindex" />
+  <meta name="googlebot" content="noindex" />
+</head>
+
 The first step to build with ComposeDB is setting up your development environment. Currently, there are two ways of how you can configure your working environment:
 
 - [Using the Wheel](#installation-using-wheel) - the recommended and the easiest way to configure your working environment and install the necessary dependencies.

--- a/website/versioned_docs/version-0.4.x/wheel-reference.mdx
+++ b/website/versioned_docs/version-0.4.x/wheel-reference.mdx
@@ -3,6 +3,11 @@ import TabItem from '@theme/TabItem'
 
 # Wheel reference 
 
+<head>
+  <meta name="robots" content="noindex" />
+  <meta name="googlebot" content="noindex" />
+</head>
+
 This reference explains Wheel prompt options and covers Ceramic configurations in more detail.
 
 ## Wheel prompt reference


### PR DESCRIPTION
# Add noindex tags to older versions of the docs - #DXC-228

[Link to Linear issue.](https://linear.app/3boxlabs/issue/DXC-228/update-no-index-tag-on-documentation)

**Problem:**
Older versions of the documentation pop up on the Google Search. While older versions of the docs should always be available on the site, we get quite a lot of traffic of the users going to the old versions of the documentation when getting started.

**Proposed solution:**
[As per docusaurus docs](https://docusaurus.io/docs/seo#robots-file), add a noindex tags to the pages of the older versions of the documentation so that they would prevent the search engines from indexing them.  