### PR TITLE
Remove container, add updated tag id

### DIFF
--- a/website/docusaurus.config.ts
+++ b/website/docusaurus.config.ts
@@ -55,11 +55,8 @@ const config: Config = {
           },
         },
         gtag: {
-          trackingID: 'G-V2Y8T342EX',
+          trackingID: 'G-TN90ML4SJS',
           anonymizeIP: true,
-        },
-        googleTagManager: {
-          containerId: 'GTM-TFSMT4ZD',
         },
         theme: {
           customCss: require.resolve('./src/css/custom.css'),

--- a/website/docusaurus.config.ts
+++ b/website/docusaurus.config.ts
@@ -55,7 +55,7 @@ const config: Config = {
           },
         },
         gtag: {
-          trackingID: 'G-TN90ML4SJS',
+          trackingID: 'G-V2Y8T342EX',
           anonymizeIP: true,
         },
         theme: {


### PR DESCRIPTION
Removing the container information that is used for installing heap and intercom. We'll move this over to the new docs. 
