### PR TITLE
Add clinet-side redirects

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -522,6 +522,9 @@ importers:
       '@docusaurus/core':
         specifier: ^3.0.1
         version: 3.0.1(@docusaurus/types@3.0.1)(@swc/core@1.3.100)(eslint@8.55.0)(react-dom@18.2.0)(react@18.2.0)(typescript@5.3.2)
+      '@docusaurus/plugin-client-redirects':
+        specifier: 3.0.1
+        version: 3.0.1(@docusaurus/types@3.0.1)(@swc/core@1.3.100)(eslint@8.55.0)(react-dom@18.2.0)(react@18.2.0)(typescript@5.3.2)
       '@docusaurus/plugin-content-docs':
         specifier: ^3.0.1
         version: 3.0.1(@swc/core@1.3.100)(eslint@8.55.0)(react-dom@18.2.0)(react@18.2.0)(typescript@5.3.2)
@@ -4705,6 +4708,43 @@ packages:
       - esbuild
       - uglify-js
       - webpack-cli
+
+  /@docusaurus/plugin-client-redirects@3.0.1(@docusaurus/types@3.0.1)(@swc/core@1.3.100)(eslint@8.55.0)(react-dom@18.2.0)(react@18.2.0)(typescript@5.3.2):
+    resolution: {integrity: sha512-CoZapnHbV3j5jsHCa/zmKaa8+H+oagHBgg91dN5I8/3kFit/xtZPfRaznvDX49cHg2nSoV74B3VMAT+bvCmzFQ==}
+    engines: {node: '>=18.0'}
+    peerDependencies:
+      react: ^18.0.0
+      react-dom: ^18.0.0
+    dependencies:
+      '@docusaurus/core': 3.0.1(@docusaurus/types@3.0.1)(@swc/core@1.3.100)(eslint@8.55.0)(react-dom@18.2.0)(react@18.2.0)(typescript@5.3.2)
+      '@docusaurus/logger': 3.0.1
+      '@docusaurus/utils': 3.0.1(@docusaurus/types@3.0.1)(@swc/core@1.3.100)
+      '@docusaurus/utils-common': 3.0.1(@docusaurus/types@3.0.1)
+      '@docusaurus/utils-validation': 3.0.1(@docusaurus/types@3.0.1)(@swc/core@1.3.100)
+      eta: 2.2.0
+      fs-extra: 11.2.0
+      lodash: 4.17.21
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
+      tslib: 2.6.2
+    transitivePeerDependencies:
+      - '@docusaurus/types'
+      - '@parcel/css'
+      - '@swc/core'
+      - '@swc/css'
+      - bufferutil
+      - csso
+      - debug
+      - esbuild
+      - eslint
+      - lightningcss
+      - supports-color
+      - typescript
+      - uglify-js
+      - utf-8-validate
+      - vue-template-compiler
+      - webpack-cli
+    dev: false
 
   /@docusaurus/plugin-content-blog@3.0.1(@swc/core@1.3.100)(eslint@8.55.0)(react-dom@18.2.0)(react@18.2.0)(typescript@5.3.2):
     resolution: {integrity: sha512-cLOvtvAyaMQFLI8vm4j26svg3ktxMPSXpuUJ7EERKoGbfpJSsgtowNHcRsaBVmfuCsRSk1HZ/yHBsUkTmHFEsg==}

--- a/website/docusaurus.config.ts
+++ b/website/docusaurus.config.ts
@@ -89,145 +89,270 @@ const config: Config = {
         redirects: [
           {
             to: 'https://developers.ceramic.network/docs/composedb/set-up-your-environment',
-            from: ['/docs/0.5.x/set-up-your-environment', '/docs/0.4.x/set-up-your-environment'],
+            from: [
+              '/docs/0.5.x/set-up-your-environment', 
+              '/docs/0.4.x/set-up-your-environment'
+            ],
           },
           {
             to: 'https://developers.ceramic.network/docs/composedb/getting-started',
-            from: ['/docs/0.5.x/getting-started', '/docs/0.4.x/getting-started'],
+            from: [
+              '/docs/0.5.x/getting-started', 
+              '/docs/0.4.x/getting-started'
+            ],
           },
           {
             to: 'https://developers.ceramic.network/docs/wheel/wheel-reference',
-            from: ['/docs/0.5.x/wheel-reference', '/docs/0.4.x/wheel-reference'],
+            from: [
+              '/docs/0.5.x/wheel-reference', 
+              '/docs/0.4.x/wheel-reference'
+            ],
           },
           {
             to: 'https://developers.ceramic.network/docs/composedb/create-your-composite',
-            from: ['/docs/0.5.x/create-your-composite', '/docs/0.4.x/create-your-composite', '/docs/0.3.x/first-composite', '/docs/0.2.x/first-composite'],
+            from: [
+              '/docs/0.5.x/create-your-composite', 
+              '/docs/0.4.x/create-your-composite', 
+              '/docs/0.3.x/first-composite', 
+              '/docs/0.2.x/first-composite'
+            ],
           },
           {
             to: 'https://developers.ceramic.network/docs/composedb/interact-with-data',
-            from: ['/docs/0.5.x/interact-with-data', '/docs/0.4.x/interact-with-data', '/docs/0.3.x/client-setup', '/docs/0.2.x/client-setup', '/docs/0.3.x/configuration'],
+            from: [
+              '/docs/0.5.x/interact-with-data', 
+              '/docs/0.4.x/interact-with-data', 
+              '/docs/0.3.x/client-setup', 
+              '/docs/0.2.x/client-setup', 
+              '/docs/0.3.x/configuration'
+            ],
           },
           {
             to: 'https://developers.ceramic.network/docs/composedb/next-steps',
-            from: ['/docs/0.5.x/next-steps', '/docs/0.4.x/next-steps'],
+            from: [
+              '/docs/0.5.x/next-steps', 
+              '/docs/0.4.x/next-steps'
+            ],
           },
           {
             to: 'https://developers.ceramic.network/docs/composedb/core-concepts',
-            from: ['/docs/0.5.x/core-concepts', '/docs/0.4.x/core-concepts', '/docs/0.3.x/guides/concepts-overview', '/docs/0.2.x/guides/concepts-overview'],
+            from: [
+              '/docs/0.5.x/core-concepts', 
+              '/docs/0.4.x/core-concepts', 
+              '/docs/0.3.x/guides/concepts-overview', 
+              '/docs/0.2.x/guides/concepts-overview'
+            ],
           },
           {
             to: 'https://developers.ceramic.network/docs/introduction/ceramic-roadmap',
-            from: ['/docs/0.4.x/ceramic-roadmap'],
+            from: '/docs/0.4.x/ceramic-roadmap',
           },
           {
             to: 'https://developers.ceramic.network/docs/ecosystem/community',
-            from: ['/docs/0.5.x/community', '/docs/0.4.x/community'],
+            from: [
+              '/docs/0.5.x/community', 
+              '/docs/0.4.x/community'
+            ],
           },
           {
             to: 'https://developers.ceramic.network/docs/composedb/examples',
-            from: ['/docs/0.5.x/examples'],
+            from: '/docs/0.5.x/examples',
           },
           {
             to: 'https://developers.ceramic.network/docs/composedb/examples/verifiable-credentials',
-            from: ['/docs/0.5.x/verifiable-credentials'],
+            from: '/docs/0.5.x/verifiable-credentials',
           },
           {
             to: 'https://developers.ceramic.network/sandbox',
-            from: ['/sandbox'],
+            from: '/sandbox',
           },
           {
             to: 'https://developers.ceramic.network/docs/composedb/guides',
-            from: ['/docs/0.5.x/guides', '/docs/0.4.x/guides', '/docs/0.3.x/guides', '/docs/0.2.x/guides'],
+            from: [
+              '/docs/0.5.x/guides', 
+              '/docs/0.4.x/guides', 
+              '/docs/0.3.x/guides', 
+              '/docs/0.2.x/guides'
+            ],
           },
           {
             to: 'https://developers.ceramic.network/docs/composedb/guides/data-modeling',
-            from: ['/docs/0.5.x/guides/data-modeling/data-modeling', '/docs/0.4.x/guides/data-modeling/data-modeling', '/docs/0.3.x/guides/data-composition', '/docs/0.2.x/guides/data-composition'],
+            from: [
+              '/docs/0.5.x/guides/data-modeling/data-modeling', 
+              '/docs/0.4.x/guides/data-modeling/data-modeling', 
+              '/docs/0.3.x/guides/data-composition', 
+              '/docs/0.2.x/guides/data-composition'
+            ],
           },
           {
             to: 'https://developers.ceramic.network/docs/composedb/guides/data-modeling/model-catalog',
-            from: ['/docs/0.5.x/guides/data-modeling/model-catalog', '/docs/0.4.x/guides/data-modeling/model-catalog', '/docs/0.3.x/guides/using-composites/discovery', '/docs/0.2.x/guides/using-composites/discovery'],
+            from: [
+              '/docs/0.5.x/guides/data-modeling/model-catalog', 
+              '/docs/0.4.x/guides/data-modeling/model-catalog', 
+              '/docs/0.3.x/guides/using-composites/discovery',
+              '/docs/0.2.x/guides/using-composites/discovery'
+            ],
           },
           {
             to: 'https://developers.ceramic.network/docs/composedb/guides/data-modeling/writing-models',
-            from: ['/docs/0.5.x/guides/data-modeling/writing-models', '/docs/0.4.x/guides/data-modeling/writing-models'],
+            from: [
+              '/docs/0.5.x/guides/data-modeling/writing-models', 
+              '/docs/0.4.x/guides/data-modeling/writing-models'
+            ],
           },
           {
             to: 'https://developers.ceramic.network/docs/composedb/guides/data-modeling/introduction-to-modeling',
-            from: ['/docs/0.5.x/guides/data-modeling/introduction-to-modeling', '/docs/0.4.x/guides/data-modeling/introduction-to-modeling'],
+            from: [
+              '/docs/0.5.x/guides/data-modeling/introduction-to-modeling', 
+              '/docs/0.4.x/guides/data-modeling/introduction-to-modeling'
+            ],
           },
           {
             to: 'https://developers.ceramic.network/docs/composedb/guides/data-modeling/schemas',
-            from: ['/docs/0.5.x/guides/data-modeling/schemas', '/docs/0.4.x/guides/data-modeling/schemas', '/docs/0.3.x/guides/creating-composites/schema', '/docs/0.2.x/guides/creating-composites/schema', '/docs/0.3.x/guides/creating-composites/scalars', '/docs/0.3.x/guides/creating-composites/directives', '/docs/0.2.x/guides/creating-composites/scalars', '/docs/0.2.x/guides/creating-composites/directives'],
+            from: [
+              '/docs/0.5.x/guides/data-modeling/schemas', 
+              '/docs/0.4.x/guides/data-modeling/schemas', 
+              '/docs/0.3.x/guides/creating-composites/schema', 
+              '/docs/0.2.x/guides/creating-composites/schema', 
+              '/docs/0.3.x/guides/creating-composites/scalars', 
+              '/docs/0.3.x/guides/creating-composites/directives',
+              '/docs/0.2.x/guides/creating-composites/scalars', 
+              '/docs/0.2.x/guides/creating-composites/directives'
+            ],
           },
           {
             to: 'https://developers.ceramic.network/docs/composedb/guides/data-modeling/relations',
-            from: ['/docs/0.5.x/guides/data-modeling/relations', '/docs/0.4.x/guides/data-modeling/relations'],
+            from: [
+              '/docs/0.5.x/guides/data-modeling/relations', 
+              '/docs/0.4.x/guides/data-modeling/relations'
+            ],
           },
           {
             to: 'https://developers.ceramic.network/docs/composedb/guides/data-modeling/relations',
-            from: ['/docs/0.5.x/guides/data-modeling/composites', '/docs/0.4.x/guides/data-modeling/composites', '/docs/0.3.x/guides/using-composites/deployment', '/docs/0.3.x/guides/using-composites/customization', '/docs/0.3.x/guides/creating-composites/overview', '/docs/0.2.x/guides/using-composites/deployment', '/docs/0.2.x/guides/using-composites/customization', '/docs/0.2.x/guides/creating-composites/overview'],
+            from: [
+              '/docs/0.5.x/guides/data-modeling/composites', 
+              '/docs/0.4.x/guides/data-modeling/composites', 
+              '/docs/0.3.x/guides/using-composites/deployment', 
+              '/docs/0.3.x/guides/using-composites/customization', 
+              '/docs/0.3.x/guides/creating-composites/overview', 
+              '/docs/0.2.x/guides/using-composites/deployment',
+              '/docs/0.2.x/guides/using-composites/customization', 
+              '/docs/0.2.x/guides/creating-composites/overview'
+            ],
           },
           {
             to: 'https://developers.ceramic.network/docs/composedb/guides/data-interactions/queries',
-            from: ['/docs/0.5.x/guides/data-interactions/queries', '/docs/0.4.x/guides/data-interactions/queries', '/docs/0.3.x/guides/interacting/queries', '/docs/0.2.x/guides/interacting/queries'],
+            from: [
+              '/docs/0.5.x/guides/data-interactions/queries', 
+              '/docs/0.4.x/guides/data-interactions/queries', 
+              '/docs/0.3.x/guides/interacting/queries',
+              '/docs/0.2.x/guides/interacting/queries'
+            ],
           },
           {
             to: 'https://developers.ceramic.network/docs/composedb/guides/data-interactions/mutations',
-            from: ['/docs/0.5.x/guides/data-interactions/mutations', '/docs/0.4.x/guides/data-interactions/mutations', '/docs/0.3.x/guides/interacting/mutations', '/docs/0.2.x/guides/interacting/mutations'],
+            from: [
+              '/docs/0.5.x/guides/data-interactions/mutations', 
+              '/docs/0.4.x/guides/data-interactions/mutations', 
+              '/docs/0.3.x/guides/interacting/mutations',
+              '/docs/0.2.x/guides/interacting/mutations'
+            ],
           },
           {
             to: 'https://developers.ceramic.network/docs/composedb/guides/composedb-client/using-apollo',
-            from: ['/docs/0.5.x/guides/composedb-client/using-apollo', '/docs/0.3.x/guides/interacting/using-apollo', '/docs/0.2.x/guides/interacting/using-apollo', '/docs/0.4.x/guides/composedb-client/using-apollo'],
+            from: [
+              '/docs/0.5.x/guides/composedb-client/using-apollo', 
+              '/docs/0.3.x/guides/interacting/using-apollo', 
+              '/docs/0.2.x/guides/interacting/using-apollo',
+              '/docs/0.4.x/guides/composedb-client/using-apollo'
+            ],
           },
           {
             to: 'https://developers.ceramic.network/docs/composedb/guides/composedb-client/using-relay',
-            from: ['/docs/0.5.x/guides/composedb-client/using-relay', '/docs/0.4.x/guides/composedb-client/using-relay', '/docs/0.3.x/guides/interacting/using-relay', '/docs/0.2.x/guides/interacting/using-relay'],
+            from: [
+              '/docs/0.5.x/guides/composedb-client/using-relay', 
+              '/docs/0.4.x/guides/composedb-client/using-relay', 
+              '/docs/0.3.x/guides/interacting/using-relay',
+              '/docs/0.2.x/guides/interacting/using-relay'
+            ],
           },
           {
             to: 'https://developers.ceramic.network/docs/composedb/guides/composedb-client',
-            from: ['/docs/0.5.x/guides/composedb-client/composedb-client', '/docs/0.4.x/guides/composedb-client/composedb-client'],
+            from: [
+              '/docs/0.5.x/guides/composedb-client/composedb-client', 
+              '/docs/0.4.x/guides/composedb-client/composedb-client'
+            ],
           },
           {
             to: 'https://developers.ceramic.network/docs/composedb/guides/composedb-client/javascript-client',
-            from: ['/docs/0.5.x/guides/composedb-client/javascript-client', '/docs/0.4.x/guides/composedb-client/javascript-client'],
+            from: [
+              '/docs/0.5.x/guides/composedb-client/javascript-client', 
+              '/docs/0.4.x/guides/composedb-client/javascript-client'
+            ],
           },
           {
             to: 'https://developers.ceramic.network/docs/composedb/guides/composedb-client/authenticate-users',
-            from: ['/docs/0.5.x/guides/composedb-client/authenticate-users', '/docs/0.4.x/guides/composedb-client/authenticate-users'],
+            from: [
+              '/docs/0.5.x/guides/composedb-client/authenticate-users', 
+              '/docs/0.4.x/guides/composedb-client/authenticate-users'
+            ],
           },
           {
             to: 'https://developers.ceramic.network/docs/composedb/guides/composedb-client/user-sessions',
-            from: ['/docs/0.5.x/guides/composedb-client/user-sessions', '/docs/0.4.x/guides/composedb-client/user-sessions'],
+            from: [
+              '/docs/0.5.x/guides/composedb-client/user-sessions', 
+              '/docs/0.4.x/guides/composedb-client/user-sessions'
+            ],
           },
           {
             to: 'https://developers.ceramic.network/docs/composedb/guides/composedb-server',
-            from: ['/docs/0.5.x/guides/composedb-server/composedb-server', '/docs/0.4.x/guides/composedb-server/composedb-server'],
+            from: [
+              '/docs/0.5.x/guides/composedb-server/composedb-server', 
+              '/docs/0.4.x/guides/composedb-server/composedb-server'
+            ],
           },
           {
             to: 'https://developers.ceramic.network/docs/composedb/guides/composedb-server/running-locally',
-            from: ['/docs/0.5.x/guides/composedb-server/running-locally', '/docs/0.4.x/guides/composedb-server/running-locally'],
+            from: [
+              '/docs/0.5.x/guides/composedb-server/running-locally', 
+              '/docs/0.4.x/guides/composedb-server/running-locally'
+            ],
           },
           {
             to: 'https://developers.ceramic.network/docs/composedb/guides/composedb-server/running-in-the-cloud',
-            from: ['/docs/0.5.x/guides/composedb-server/running-in-the-cloud', '/docs/0.4.x/guides/composedb-server/running-in-the-cloud'],
+            from: [
+              '/docs/0.5.x/guides/composedb-server/running-in-the-cloud', 
+              '/docs/0.4.x/guides/composedb-server/running-in-the-cloud'
+            ],
           },
           {
             to: 'https://developers.ceramic.network/docs/composedb/guides/composedb-server/server-configurations',
-            from: ['/docs/0.5.x/guides/composedb-server/server-configurations', '/docs/0.4.x/guides/composedb-server/server-configurations'],
+            from: [
+              '/docs/0.5.x/guides/composedb-server/server-configurations', 
+              '/docs/0.4.x/guides/composedb-server/server-configurations'
+            ],
           },
           {
             to: 'https://developers.ceramic.network/docs/composedb/guides/composedb-server/access-mainnet',
-            from: ['/docs/0.5.x/guides/composedb-server/access-mainnet', '/docs/0.4.x/guides/composedb-server/access-mainnet'],
+            from: [
+              '/docs/0.5.x/guides/composedb-server/access-mainnet', 
+              '/docs/0.4.x/guides/composedb-server/access-mainnet'
+            ],
           },
           {
             to: 'https://developers.ceramic.network/docs/composedb/guides/composedb-server/data-storage',
-            from: ['/docs/0.5.x/guides/composedb-server/data-storage', '/docs/0.4.x/guides/composedb-server/data-storage'],
+            from: [
+              '/docs/0.5.x/guides/composedb-server/data-storage', 
+              '/docs/0.4.x/guides/composedb-server/data-storage'
+            ],
           },
           {
             to: 'https://developers.ceramic.network/docs/composedb/guides/data-interactions',
-            from: ['/docs/0.5.x/guides/data-interactions/data-interactions', '/docs/0.4.x/guides/data-interactions/data-interactions'],
+            from: [
+              '/docs/0.5.x/guides/data-interactions/data-interactions', 
+              '/docs/0.4.x/guides/data-interactions/data-interactions'
+            ],
           },
-
         ],
       },
     ],

--- a/website/docusaurus.config.ts
+++ b/website/docusaurus.config.ts
@@ -82,6 +82,155 @@ const config: Config = {
         },
       },
     ],
+    [
+      '@docusaurus/plugin-client-redirects',
+      {
+        fromExtensions: ['html', 'htm'],
+        redirects: [
+          {
+            to: 'https://developers.ceramic.network/docs/composedb/set-up-your-environment',
+            from: ['/docs/0.5.x/set-up-your-environment', '/docs/0.4.x/set-up-your-environment'],
+          },
+          {
+            to: 'https://developers.ceramic.network/docs/composedb/getting-started',
+            from: ['/docs/0.5.x/getting-started', '/docs/0.4.x/getting-started'],
+          },
+          {
+            to: 'https://developers.ceramic.network/docs/wheel/wheel-reference',
+            from: ['/docs/0.5.x/wheel-reference', '/docs/0.4.x/wheel-reference'],
+          },
+          {
+            to: 'https://developers.ceramic.network/docs/composedb/create-your-composite',
+            from: ['/docs/0.5.x/create-your-composite', '/docs/0.4.x/create-your-composite', '/docs/0.3.x/first-composite', '/docs/0.2.x/first-composite'],
+          },
+          {
+            to: 'https://developers.ceramic.network/docs/composedb/interact-with-data',
+            from: ['/docs/0.5.x/interact-with-data', '/docs/0.4.x/interact-with-data', '/docs/0.3.x/client-setup', '/docs/0.2.x/client-setup', '/docs/0.3.x/configuration'],
+          },
+          {
+            to: 'https://developers.ceramic.network/docs/composedb/next-steps',
+            from: ['/docs/0.5.x/next-steps', '/docs/0.4.x/next-steps'],
+          },
+          {
+            to: 'https://developers.ceramic.network/docs/composedb/core-concepts',
+            from: ['/docs/0.5.x/core-concepts', '/docs/0.4.x/core-concepts', '/docs/0.3.x/guides/concepts-overview', '/docs/0.2.x/guides/concepts-overview'],
+          },
+          {
+            to: 'https://developers.ceramic.network/docs/introduction/ceramic-roadmap',
+            from: ['/docs/0.4.x/ceramic-roadmap'],
+          },
+          {
+            to: 'https://developers.ceramic.network/docs/ecosystem/community',
+            from: ['/docs/0.5.x/community', '/docs/0.4.x/community'],
+          },
+          {
+            to: 'https://developers.ceramic.network/docs/composedb/examples',
+            from: ['/docs/0.5.x/examples'],
+          },
+          {
+            to: 'https://developers.ceramic.network/docs/composedb/examples/verifiable-credentials',
+            from: ['/docs/0.5.x/verifiable-credentials'],
+          },
+          {
+            to: 'https://developers.ceramic.network/sandbox',
+            from: ['/sandbox'],
+          },
+          {
+            to: 'https://developers.ceramic.network/docs/composedb/guides',
+            from: ['/docs/0.5.x/guides', '/docs/0.4.x/guides', '/docs/0.3.x/guides', '/docs/0.2.x/guides'],
+          },
+          {
+            to: 'https://developers.ceramic.network/docs/composedb/guides/data-modeling',
+            from: ['/docs/0.5.x/guides/data-modeling/data-modeling', '/docs/0.4.x/guides/data-modeling/data-modeling', '/docs/0.3.x/guides/data-composition', '/docs/0.2.x/guides/data-composition'],
+          },
+          {
+            to: 'https://developers.ceramic.network/docs/composedb/guides/data-modeling/model-catalog',
+            from: ['/docs/0.5.x/guides/data-modeling/model-catalog', '/docs/0.4.x/guides/data-modeling/model-catalog', '/docs/0.3.x/guides/using-composites/discovery', '/docs/0.2.x/guides/using-composites/discovery'],
+          },
+          {
+            to: 'https://developers.ceramic.network/docs/composedb/guides/data-modeling/writing-models',
+            from: ['/docs/0.5.x/guides/data-modeling/writing-models', '/docs/0.4.x/guides/data-modeling/writing-models'],
+          },
+          {
+            to: 'https://developers.ceramic.network/docs/composedb/guides/data-modeling/introduction-to-modeling',
+            from: ['/docs/0.5.x/guides/data-modeling/introduction-to-modeling', '/docs/0.4.x/guides/data-modeling/introduction-to-modeling'],
+          },
+          {
+            to: 'https://developers.ceramic.network/docs/composedb/guides/data-modeling/schemas',
+            from: ['/docs/0.5.x/guides/data-modeling/schemas', '/docs/0.4.x/guides/data-modeling/schemas', '/docs/0.3.x/guides/creating-composites/schema', '/docs/0.2.x/guides/creating-composites/schema', '/docs/0.3.x/guides/creating-composites/scalars', '/docs/0.3.x/guides/creating-composites/directives', '/docs/0.2.x/guides/creating-composites/scalars', '/docs/0.2.x/guides/creating-composites/directives'],
+          },
+          {
+            to: 'https://developers.ceramic.network/docs/composedb/guides/data-modeling/relations',
+            from: ['/docs/0.5.x/guides/data-modeling/relations', '/docs/0.4.x/guides/data-modeling/relations'],
+          },
+          {
+            to: 'https://developers.ceramic.network/docs/composedb/guides/data-modeling/relations',
+            from: ['/docs/0.5.x/guides/data-modeling/composites', '/docs/0.4.x/guides/data-modeling/composites', '/docs/0.3.x/guides/using-composites/deployment', '/docs/0.3.x/guides/using-composites/customization', '/docs/0.3.x/guides/creating-composites/overview', '/docs/0.2.x/guides/using-composites/deployment', '/docs/0.2.x/guides/using-composites/customization', '/docs/0.2.x/guides/creating-composites/overview'],
+          },
+          {
+            to: 'https://developers.ceramic.network/docs/composedb/guides/data-interactions/queries',
+            from: ['/docs/0.5.x/guides/data-interactions/queries', '/docs/0.4.x/guides/data-interactions/queries', '/docs/0.3.x/guides/interacting/queries', '/docs/0.2.x/guides/interacting/queries'],
+          },
+          {
+            to: 'https://developers.ceramic.network/docs/composedb/guides/data-interactions/mutations',
+            from: ['/docs/0.5.x/guides/data-interactions/mutations', '/docs/0.4.x/guides/data-interactions/mutations', '/docs/0.3.x/guides/interacting/mutations', '/docs/0.2.x/guides/interacting/mutations'],
+          },
+          {
+            to: 'https://developers.ceramic.network/docs/composedb/guides/composedb-client/using-apollo',
+            from: ['/docs/0.5.x/guides/composedb-client/using-apollo', '/docs/0.3.x/guides/interacting/using-apollo', '/docs/0.2.x/guides/interacting/using-apollo', '/docs/0.4.x/guides/composedb-client/using-apollo'],
+          },
+          {
+            to: 'https://developers.ceramic.network/docs/composedb/guides/composedb-client/using-relay',
+            from: ['/docs/0.5.x/guides/composedb-client/using-relay', '/docs/0.4.x/guides/composedb-client/using-relay', '/docs/0.3.x/guides/interacting/using-relay', '/docs/0.2.x/guides/interacting/using-relay'],
+          },
+          {
+            to: 'https://developers.ceramic.network/docs/composedb/guides/composedb-client',
+            from: ['/docs/0.5.x/guides/composedb-client/composedb-client', '/docs/0.4.x/guides/composedb-client/composedb-client'],
+          },
+          {
+            to: 'https://developers.ceramic.network/docs/composedb/guides/composedb-client/javascript-client',
+            from: ['/docs/0.5.x/guides/composedb-client/javascript-client', '/docs/0.4.x/guides/composedb-client/javascript-client'],
+          },
+          {
+            to: 'https://developers.ceramic.network/docs/composedb/guides/composedb-client/authenticate-users',
+            from: ['/docs/0.5.x/guides/composedb-client/authenticate-users', '/docs/0.4.x/guides/composedb-client/authenticate-users'],
+          },
+          {
+            to: 'https://developers.ceramic.network/docs/composedb/guides/composedb-client/user-sessions',
+            from: ['/docs/0.5.x/guides/composedb-client/user-sessions', '/docs/0.4.x/guides/composedb-client/user-sessions'],
+          },
+          {
+            to: 'https://developers.ceramic.network/docs/composedb/guides/composedb-server',
+            from: ['/docs/0.5.x/guides/composedb-server/composedb-server', '/docs/0.4.x/guides/composedb-server/composedb-server'],
+          },
+          {
+            to: 'https://developers.ceramic.network/docs/composedb/guides/composedb-server/running-locally',
+            from: ['/docs/0.5.x/guides/composedb-server/running-locally', '/docs/0.4.x/guides/composedb-server/running-locally'],
+          },
+          {
+            to: 'https://developers.ceramic.network/docs/composedb/guides/composedb-server/running-in-the-cloud',
+            from: ['/docs/0.5.x/guides/composedb-server/running-in-the-cloud', '/docs/0.4.x/guides/composedb-server/running-in-the-cloud'],
+          },
+          {
+            to: 'https://developers.ceramic.network/docs/composedb/guides/composedb-server/server-configurations',
+            from: ['/docs/0.5.x/guides/composedb-server/server-configurations', '/docs/0.4.x/guides/composedb-server/server-configurations'],
+          },
+          {
+            to: 'https://developers.ceramic.network/docs/composedb/guides/composedb-server/access-mainnet',
+            from: ['/docs/0.5.x/guides/composedb-server/access-mainnet', '/docs/0.4.x/guides/composedb-server/access-mainnet'],
+          },
+          {
+            to: 'https://developers.ceramic.network/docs/composedb/guides/composedb-server/data-storage',
+            from: ['/docs/0.5.x/guides/composedb-server/data-storage', '/docs/0.4.x/guides/composedb-server/data-storage'],
+          },
+          {
+            to: 'https://developers.ceramic.network/docs/composedb/guides/data-interactions',
+            from: ['/docs/0.5.x/guides/data-interactions/data-interactions', '/docs/0.4.x/guides/data-interactions/data-interactions'],
+          },
+
+        ],
+      },
+    ],
   ],
   themeConfig: {
     algolia: {

--- a/website/package.json
+++ b/website/package.json
@@ -23,6 +23,7 @@
     "@docusaurus/core": "^3.0.1",
     "@docusaurus/plugin-content-docs": "^3.0.1",
     "@docusaurus/plugin-google-tag-manager": "^3.0.1",
+    "@docusaurus/plugin-client-redirects": "3.0.1",
     "@docusaurus/preset-classic": "^3.0.1",
     "@docusaurus/theme-common": "3.0.1",
     "@graphiql/toolkit": "^0.9.1",


### PR DESCRIPTION

## Description

Since the docs migration we haven't added the 1:1 redirects for the old composedb pages to the new site. This PR adds client-side redirects to the new site for relevant pages.