### PR TITLE
Update docs for v0.7

### DIFF
--- a/packages/loader/src/loader.ts
+++ b/packages/loader/src/loader.ts
@@ -142,6 +142,7 @@ export class DocumentLoader extends DataLoader<LoadKey, ModelInstanceDocument, s
 
   /**
    * Get or create the LoadKey for a deterministic stream.
+   * @internal
    */
   _getDeterministicKey(meta: GenesisMetadata): Promise<LoadKey> {
     const cacheKey = getDeterministicCacheKey(meta)
@@ -189,6 +190,7 @@ export class DocumentLoader extends DataLoader<LoadKey, ModelInstanceDocument, s
 
   /**
    * Load a deterministic stream and add it to the cache.
+   * @internal
    */
   async _loadDeterministic<T extends Record<string, any> = Record<string, any>>(
     meta: GenesisMetadata,

--- a/packages/runtime/src/context.ts
+++ b/packages/runtime/src/context.ts
@@ -115,7 +115,7 @@ export function createContext(params: ContextParams): Context {
         ...opts,
         onlyIndexed: false,
       })
-      await doc!.replace(content, typeof shouldIndex === 'undefined' ? undefined : { shouldIndex })
+      await doc!.replace(content, { shouldIndex: shouldIndex !== false })
       return doc
     },
     upsertSet: async <Content extends Record<string, any> = Record<string, any>>(
@@ -133,7 +133,7 @@ export function createContext(params: ContextParams): Context {
         ...opts,
         onlyIndexed: false,
       })
-      await doc!.replace(content, typeof shouldIndex === 'undefined' ? undefined : { shouldIndex })
+      await doc!.replace(content, { shouldIndex: shouldIndex !== false })
       return doc
     },
     queryCount: async (query: BaseQuery): Promise<number> => {

--- a/packages/runtime/test/context.test.ts
+++ b/packages/runtime/test/context.test.ts
@@ -89,7 +89,7 @@ describe('context', () => {
       const content = {}
       await expect(context.upsertSingle('testID', content)).resolves.toBe(expectedDoc)
       expect(loadSingle).toHaveBeenCalledWith('did:test:123', 'testID', { onlyIndexed: false })
-      expect(replace).toHaveBeenCalledWith(content, undefined)
+      expect(replace).toHaveBeenCalledWith(content, { shouldIndex: true })
     })
 
     test('uses the loadSingle() method of the loader with options', async () => {
@@ -140,7 +140,7 @@ describe('context', () => {
       const content = {}
       await expect(context.upsertSet('testID', unique, content)).resolves.toBe(expectedDoc)
       expect(loadSet).toHaveBeenCalledWith('did:test:123', 'testID', unique, { onlyIndexed: false })
-      expect(replace).toHaveBeenCalledWith(content, undefined)
+      expect(replace).toHaveBeenCalledWith(content, { shouldIndex: true })
     })
 
     test('uses the loadSet() method of the loader with options', async () => {

--- a/website/docs/api/classes/loader.DocumentLoader.md
+++ b/website/docs/api/classes/loader.DocumentLoader.md
@@ -42,49 +42,6 @@ DataLoader\&lt;LoadKey, ModelInstanceDocument, string\&gt;.constructor
 
 ## Methods
 
-### \_getDeterministicKey
-
-▸ **_getDeterministicKey**(`meta`): `Promise`\<[`LoadKey`](../modules/loader.md#loadkey)\>
-
-Get or create the LoadKey for a deterministic stream.
-
-#### Parameters
-
-| Name | Type |
-| :------ | :------ |
-| `meta` | `GenesisMetadata` |
-
-#### Returns
-
-`Promise`\<[`LoadKey`](../modules/loader.md#loadkey)\>
-
-___
-
-### \_loadDeterministic
-
-▸ **_loadDeterministic**\<`T`\>(`meta`, `options?`): `Promise`\<`ModelInstanceDocument`\<`T`\>\>
-
-Load a deterministic stream and add it to the cache.
-
-#### Type parameters
-
-| Name | Type |
-| :------ | :------ |
-| `T` | extends `Record`\<`string`, `any`\> = `Record`\<`string`, `any`\> |
-
-#### Parameters
-
-| Name | Type |
-| :------ | :------ |
-| `meta` | `GenesisMetadata` |
-| `options` | `CreateOpts` |
-
-#### Returns
-
-`Promise`\<`ModelInstanceDocument`\<`T`\>\>
-
-___
-
 ### cache
 
 ▸ **cache**(`stream`): `boolean`
@@ -159,7 +116,7 @@ ___
 
 ### loadSet
 
-▸ **loadSet**\<`T`\>(`controller`, `model`, `unique`, `options?`): `Promise`\<`ModelInstanceDocument`\<`T`\>\>
+▸ **loadSet**\<`T`\>(`controller`, `model`, `unique`, `options?`): `Promise`\<``null`` \| `ModelInstanceDocument`\<`T`\>\>
 
 Create or load a deterministic ModelInstanceDocument using the SET account
 relation and cache it.
@@ -177,17 +134,17 @@ relation and cache it.
 | `controller` | `string` |
 | `model` | `string` \| `StreamID` |
 | `unique` | `string`[] |
-| `options?` | `CreateOpts` |
+| `options?` | [`DeterministicLoadOptions`](../modules/loader.md#deterministicloadoptions) |
 
 #### Returns
 
-`Promise`\<`ModelInstanceDocument`\<`T`\>\>
+`Promise`\<``null`` \| `ModelInstanceDocument`\<`T`\>\>
 
 ___
 
 ### loadSingle
 
-▸ **loadSingle**\<`T`\>(`controller`, `model`, `options?`): `Promise`\<`ModelInstanceDocument`\<`T`\>\>
+▸ **loadSingle**\<`T`\>(`controller`, `model`, `options?`): `Promise`\<``null`` \| `ModelInstanceDocument`\<`T`\>\>
 
 Create or load a deterministic ModelInstanceDocument and cache it.
 
@@ -203,11 +160,47 @@ Create or load a deterministic ModelInstanceDocument and cache it.
 | :------ | :------ |
 | `controller` | `string` |
 | `model` | `string` \| `StreamID` |
-| `options?` | `CreateOpts` |
+| `options?` | [`DeterministicLoadOptions`](../modules/loader.md#deterministicloadoptions) |
 
 #### Returns
 
-`Promise`\<`ModelInstanceDocument`\<`T`\>\>
+`Promise`\<``null`` \| `ModelInstanceDocument`\<`T`\>\>
+
+___
+
+### queryConnection
+
+▸ **queryConnection**(`query`): `Promise`\<`Connection`\<``null`` \| `ModelInstanceDocument`\<`Record`\<`string`, `any`\>\>\>\>
+
+Query the index for multiple ModelInstanceDocument streams and cache the results.
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `query` | [`ConnectionQuery`](../modules/loader.md#connectionquery) |
+
+#### Returns
+
+`Promise`\<`Connection`\<``null`` \| `ModelInstanceDocument`\<`Record`\<`string`, `any`\>\>\>\>
+
+___
+
+### queryOne
+
+▸ **queryOne**(`query`): `Promise`\<``null`` \| `ModelInstanceDocument`\<`Record`\<`string`, `any`\>\>\>
+
+Query the index for a single ModelInstanceDocument stream and cache it.
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `query` | `BaseQuery` |
+
+#### Returns
+
+`Promise`\<``null`` \| `ModelInstanceDocument`\<`Record`\<`string`, `any`\>\>\>
 
 ___
 

--- a/website/docs/api/modules/devtools.md
+++ b/website/docs/api/modules/devtools.md
@@ -132,6 +132,7 @@ ___
 
 | Name | Type |
 | :------ | :------ |
+| `immutable?` | `boolean` |
 | `required` | `boolean` |
 
 ___
@@ -216,6 +217,7 @@ ___
 | `accountRelation` | `ModelAccountRelationV2` |
 | `action` | ``"create"`` |
 | `description` | `string` |
+| `immutableFields` | `string`[] |
 | `implements` | `string`[] |
 | `interface` | `boolean` |
 | `relations` | `ModelRelationsDefinitionV2` |
@@ -299,3 +301,19 @@ ___
 #### Returns
 
 [`AbstractCompositeDefinition`](devtools.md#abstractcompositedefinition)
+
+___
+
+### isRelationViewDefinition
+
+▸ **isRelationViewDefinition**(`view`): view is MapIn\<Object, $TypeOf\> \| MapIn\<Object, $TypeOf\> \| MapIn\<Object, $TypeOf\> \| MapIn\<Object, $TypeOf\>
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `view` | `MapIn`\<{}, `$TypeOf`\> \| `MapIn`\<{}, `$TypeOf`\> \| `MapIn`\<{}, `$TypeOf`\> \| `MapIn`\<{}, `$TypeOf`\> \| `MapIn`\<{}, `$TypeOf`\> \| `MapIn`\<{}, `$TypeOf`\> |
+
+#### Returns
+
+view is MapIn\<Object, $TypeOf\> \| MapIn\<Object, $TypeOf\> \| MapIn\<Object, $TypeOf\> \| MapIn\<Object, $TypeOf\>

--- a/website/docs/api/modules/loader.md
+++ b/website/docs/api/modules/loader.md
@@ -40,15 +40,27 @@ npm install @composedb/loader
 
 ___
 
+### ConnectionQuery
+
+Ƭ **ConnectionQuery**: `BaseQuery` & `ConnectionArguments`
+
+___
+
 ### CreateOptions
 
-Ƭ **CreateOptions**: `CreateOpts` & \{ `controller?`: `string`  }
+Ƭ **CreateOptions**: `CreateOpts` & \{ `controller?`: `string` ; `shouldIndex?`: `boolean`  }
 
 ___
 
 ### DeterministicKeysCache
 
 Ƭ **DeterministicKeysCache**: [`CacheMap`](loader.md#cachemap)\<[`LoadKey`](loader.md#loadkey)\>
+
+___
+
+### DeterministicLoadOptions
+
+Ƭ **DeterministicLoadOptions**: [`CreateOptions`](loader.md#createoptions) & \{ `onlyIndexed?`: `boolean`  }
 
 ___
 
@@ -102,6 +114,7 @@ ___
 | Name | Type |
 | :------ | :------ |
 | `replace?` | `boolean` |
+| `shouldIndex?` | `boolean` |
 | `version?` | `string` |
 
 ___

--- a/website/docs/api/modules/runtime.md
+++ b/website/docs/api/modules/runtime.md
@@ -33,17 +33,13 @@ ___
 | Name | Type | Description |
 | :------ | :------ | :------ |
 | `ceramic` | `CeramicAPI` | Ceramic client instance used internally. |
-| `createDoc` | \<Content\>(`model`: `string`, `content`: `Content`) => `Promise`\<`ModelInstanceDocument`\<`Content`\>\> | Create a new document with the given model and content. |
 | `getViewerID` | () => `string` \| ``null`` | ID of the current viewer (authenticated DID), if set. |
 | `isAuthenticated` | () => `boolean` | Returns whether the Ceramic client instance used internally is authenticated or not. When not authenticated, mutations will fail. |
-| `loadDoc` | \<Content\>(`id`: `string` \| `CommitID` \| `StreamID`, `fresh?`: `boolean`) => `Promise`\<`ModelInstanceDocument`\<`Content`\>\> | Load a document by ID, using the cache if possible. |
+| `loadDoc` | \<Content\>(`id`: `string` \| `CommitID` \| `StreamID`, `fresh?`: `boolean`) => `Promise`\<`ModelInstanceDocument`\<`Content`\> \| ``null``\> | Load a document by ID, using the cache if possible. |
 | `loader` | `DocumentLoader` | Document loader instance used internally. |
-| `queryConnection` | (`query`: `ConnectionQuery`) => `Promise`\<`Connection`\<`ModelInstanceDocument` \| ``null``\>\> | Query the index for a connection of documents. |
 | `queryCount` | (`query`: `BaseQuery`) => `Promise`\<`number`\> | Query the index for the total number of documents matching the query parameters. |
-| `queryOne` | (`query`: `BaseQuery`) => `Promise`\<`ModelInstanceDocument` \| ``null``\> | Query the index for a single document. |
-| `updateDoc` | \<Content\>(`id`: `string` \| `StreamID`, `content`: `Content`, `options?`: `UpdateDocOptions`) => `Promise`\<`ModelInstanceDocument`\<`Content`\>\> | Update an existing document. |
-| `upsertSet` | \<Content\>(`model`: `string`, `unique`: `string`[], `content`: `Content`, `options?`: `CreateOpts`) => `Promise`\<`ModelInstanceDocument`\<`Content`\>\> | Create or update a document using the SET account relation with the given model, content and unique fields value. |
-| `upsertSingle` | \<Content\>(`model`: `string`, `content`: `Content`, `options?`: `CreateOpts`) => `Promise`\<`ModelInstanceDocument`\<`Content`\>\> | Create or update a document using the SINGLE account relation with the given model and content. |
+| `upsertSet` | \<Content\>(`model`: `string`, `unique`: `string`[], `content`: `Content`, `options?`: `UpsertOptions`) => `Promise`\<`ModelInstanceDocument`\<`Content`\> \| ``null``\> | Create or update a document using the SET account relation with the given model, content and unique fields value. |
+| `upsertSingle` | \<Content\>(`model`: `string`, `content`: `Content`, `options?`: `UpsertOptions`) => `Promise`\<`ModelInstanceDocument`\<`Content`\> \| ``null``\> | Create or update a document using the SINGLE account relation with the given model and content. |
 
 ___
 

--- a/website/docs/api/sdl/directives.mdx
+++ b/website/docs/api/sdl/directives.mdx
@@ -10,14 +10,17 @@ The `@createModel` directive applies to shapes and interfaces, indicating they
 need to be created as a Model. A Composite must contain at least one Model to
 be valid, otherwise there would be nothing to interact with.
 
-When using the `@createModel` directive, two parameters must be provided:
+When using the `@createModel` directive, the following parameters can be provided:
 
+- `description` (required): a string describing the Model, to help with discovery.
 - `accountRelation`: the type of relation between documents created using the
   Model and the account controlling the document, which can be `SINGLE` for a
-  single document of the given Model (for example profile information), or
+  single document of the given Model (for example profile information), `SET`
+  for multiple dterministic documents based on one or more content fields, or
   `LIST` (default) for a potentially infinite list of documents. When creating
   interfaces, the `accountRelation` is ignored if provided.
-- `description`: a string describing the Model, to help with discovery.
+- `accountRelationFields`: a list of content field names defining the `SET` account
+  relation. This argument is required when the `accountRelation` is `SET`.
 
 Example:
 
@@ -224,8 +227,8 @@ type Comment @createModel(accountRelation: LIST, description: "A comment on a Po
 ### `@relationFrom`
 
 Defines a field representing an inverse relation of documents pointing to the
-current document for a given `model` and `property` identified by the arguments
-of the directive.
+current document for a referenced model and a given `property` identified by the
+arguments of the directive.
 
 Example where a `comments` view is added to an existing Post model, using the
 Comment model described in the
@@ -237,7 +240,7 @@ type Comment @loadModel(id: "<Comment model stream ID>") {
 }
 
 type Post @loadModel(id: "<Post model stream ID>") {
-  comments: [Comment] @relationFrom(model: "Comment", property: "postID")
+  comments: [Comment] @relationFrom(property: "postID")
 }
 ```
 
@@ -258,5 +261,31 @@ type Comment @loadModel(id: "<Comment model stream ID>") {
 
 type Post @loadModel(id: "<Post model stream ID>") {
   commentsCount: Int! @relationCountFrom(model: "Comment", property: "postID")
+}
+```
+
+### `@relationSetFrom`
+
+Defines a field representing a single document with a model using the `SET`
+account relation for a referenced model and a given `property` identified by
+the arguments of the directive.
+
+Example where a `like` view is added to an existing Post model:
+
+```graphql {6}
+type Like
+  @createModel(
+    description: "A positive reaction to a Post"
+    # Models referenced by the @relationSetFrom view MUST use the SET account relation
+    accountRelation: SET
+    # Fields defining the SET relation
+    accountRelationFields: ["postID"]
+  ) {
+  postID: StreamID! @documentReference(model: "Post")
+  post: Post! @relationDocument(property: "postID")
+}
+
+type Post @loadModel(id: "<Post model stream ID>") {
+  like: Like @relationSetFrom(property: "postID")
 }
 ```


### PR DESCRIPTION
Mostly docs fixes and generated APIs updates, the main content change is about the directives to add the `SET` account relation and the `accountRelationFields`.

A small functional change as well is defaulting the `shouldIndex` to `true` when calling the `set<Model>` mutations, so unless the `shouldIndex` option is explicitly set to `false`, the document should be indexed, I think this behavior would better match the expectations.