### PR TITLE
feat: add graphql:execute

### DIFF
--- a/packages/cli/globalSetup.js
+++ b/packages/cli/globalSetup.js
@@ -19,6 +19,7 @@ const TEST_DAEMON_CONFIG = {
     'admin-dids': [
       'did:key:z6Mkh3VVZHjMWmBFkmixiYsZmJYAEkASk4ScjZDkawn6Npcu', // used in composites.test.ts
       'did:key:z6MkpRhEWywReoFtQMQGqSmTu5mp9vQVok86Qha2sn6e32Db', // used in models.test.ts
+      'did:key:z6MkemC7PdH6hm6xJ764qN3xbWYyUfc8S2pgkDvYsBcLZUqw', // used in graphql.test.ts
     ],
     'cors-allowed-origins': [new RegExp('.*')],
   },

--- a/packages/cli/src/commands/graphql/execute.ts
+++ b/packages/cli/src/commands/graphql/execute.ts
@@ -6,7 +6,7 @@ import fs from 'fs-extra'
 
 export default class Execute extends Command<
   CommandFlags,
-  { query: string; vars: Record<string, any>; }
+  { query: string; vars: Record<string, any> }
 > {
   static description = 'execute a GraphQL query or mutation'
 
@@ -17,7 +17,8 @@ export default class Execute extends Command<
     }),
     vars: Args.custom({
       required: false,
-      description: 'variables as JSON to provide to a mutation. A "did" variable is always added that is the DID from the environment.',
+      description:
+        'variables as JSON to provide to a mutation. A "did" variable is always added that is the DID from the environment.',
       parse: (input) => Promise.resolve(JSON.parse(input)),
     })(),
   }
@@ -33,7 +34,8 @@ export default class Execute extends Command<
   async run(): Promise<void> {
     this.spinner.start('Executing GraphQL...')
     try {
-      const runtimeDefinitionPath = this.flags.runtimeDefinitionPath as string || 'runtime-composite.json'
+      const runtimeDefinitionPath =
+        (this.flags.runtimeDefinitionPath as string) || 'runtime-composite.json'
       const runtimeDefinitionFile = await fs.readFile(runtimeDefinitionPath)
       const definition = JSON.parse(runtimeDefinitionFile.toString()) as RuntimeCompositeDefinition
       const compose = new ComposeClient({ ceramic: this.ceramic, definition })

--- a/packages/cli/src/commands/graphql/execute.ts
+++ b/packages/cli/src/commands/graphql/execute.ts
@@ -1,0 +1,52 @@
+import { Command, type CommandFlags } from '../../command.js'
+import { Args } from '@oclif/core'
+import { ComposeClient } from '@composedb/client'
+import { RuntimeCompositeDefinition } from '@composedb/types'
+import fs from 'fs-extra'
+
+export default class Execute extends Command<
+  CommandFlags,
+  { query: string; vars: Record<string, any>; }
+> {
+  static description = 'execute a GraphQL query or mutation'
+
+  static args = {
+    query: Args.string({
+      required: true,
+      description: 'GraphQL query or mutation',
+    }),
+    vars: Args.custom({
+      required: false,
+      description: 'variables as JSON to provide to a mutation. A "did" variable is always added that is the DID from the environment.',
+      parse: (input) => Promise.resolve(JSON.parse(input)),
+    })(),
+  }
+
+  static flags = {
+    ...Command.flags,
+    runtimeDefinitionPath: Args.string({
+      required: false,
+      description: 'path to runtime-composite definition json file',
+    }),
+  }
+
+  async run(): Promise<void> {
+    this.spinner.start('Executing GraphQL...')
+    try {
+      const runtimeDefinitionPath = this.flags.runtimeDefinitionPath as string || 'runtime-composite.json'
+      const runtimeDefinitionFile = await fs.readFile(runtimeDefinitionPath)
+      const definition = JSON.parse(runtimeDefinitionFile.toString()) as RuntimeCompositeDefinition
+      const compose = new ComposeClient({ ceramic: this.ceramic, definition })
+      compose.setDID(this.authenticatedDID)
+      const vars = {
+        ...this.args.vars,
+        did: compose.id,
+      }
+      this.log(JSON.stringify(await compose.executeQuery(this.args.query, vars), undefined, '  '))
+      this.spinner.succeed(`Executing GraphQL... Done!`)
+    } catch (e) {
+      console.log((e as Error).stack)
+      this.spinner.fail((e as Error).message)
+    }
+  }
+}


### PR DESCRIPTION
## Description

Adds command to execute arbitrary graphql queries and mutations.

## How Has This Been Tested?

Ran various queries and mutations

## Definition of Done

Before submitting this PR, please make sure:

- [x] The work addresses the description and outcomes in the issue
- [ ] I have added relevant tests for new or updated functionality
- [ ] My code follows conventions, is well commented, and easy to understand
- [ ] My code builds and tests pass without any errors or warnings
- [ ] I have tagged the relevant reviewers
- [ ] I have updated the READMEs of affected packages
- [ ] I have made corresponding changes to the documentation
- [ ] The changes have been communicated to interested parties

## References:

https://github.com/ceramicstudio/js-composedb/pull/217
