### PR TITLE
feat: add github workflow to publish composedb-cli image

### DIFF
--- a/.github/workflows/docker-cli.yaml
+++ b/.github/workflows/docker-cli.yaml
@@ -42,3 +42,9 @@ jobs:
           build-args: |
             VERSION=${{ steps.package-version.outputs.version }}
           tags: ${{ env.DOCKER_IMAGE }}:${{ steps.package-version.outputs.version }}
+
+      - name: Push Docker image with latest tag (if default branch)
+        if: github.event.inputs.branch == 'main'
+        run: |
+          docker tag ${{ env.DOCKER_IMAGE }}:${{ steps.extract_version.outputs.version }} ${{ env.DOCKER_IMAGE }}:latest
+          docker push ${{ env.DOCKER_IMAGE }}:latest

--- a/.github/workflows/docker-cli.yaml
+++ b/.github/workflows/docker-cli.yaml
@@ -1,0 +1,44 @@
+name: Build and Push composed-cli Docker Image
+
+on:
+  workflow_dispatch:
+    inputs:
+      branch:
+        description: "Branch name"
+        default: "main"
+        required: true
+
+env:
+  DOCKER_IMAGE: ceramicnetwork/composedb-cli
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.inputs.branch }}
+
+      - name: Read package.json
+        id: package-version
+        run: echo "::set-output name=version::$(jq -r '.version' ./packages/cli/package.json)"
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Login to DockerHub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v3
+        with:
+          context: .
+          push: true
+          build-args: |
+            VERSION=${{ steps.package-version.outputs.version }}
+          tags: ${{ env.DOCKER_IMAGE }}:${{ steps.package-version.outputs.version }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,5 @@
+FROM node:20
+ARG COMPOSEDB_CLI_VERSION=latest
+RUN npm install --location=global @composedb/cli@${COMPOSEDB_CLI_VERSION}
+
+ENTRYPOINT ["composedb"]


### PR DESCRIPTION
Publish an image for composedb-cli so that we can use the did tools to convert private keys to dids in keramik.